### PR TITLE
Bandernatch VRFS temporary patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.7.0", default-features = false, features = ["derive"
 schnorrkel = { version = "0.10.2", default-features = false, features = ["u64_backend"] }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.12", default-features = false }
-bandersnatch_vrfs = { git = "https://github.com/w3f/ring-vrf.git", default-features = false }
+bandersnatch_vrfs = { git = "https://github.com/davxy/ring-vrf.git", rev = "48b642a", default-features = false }
 
 [dev-dependencies]
 rand_core = "0.6"


### PR DESCRIPTION
This update reroutes `bandersnatch_vrfs` to the one in my repository,  which is patched to use a specific revision of `ring-proof`, along with some necessary code adjustments. This revision of `ring-proof` has been verified and is currently in use with JAM.

Once https://github.com/w3f/ring-proof/issues/38 is resolved, I will integrate the released crate into `ark-ec-vrfs`, which will then replace `bandersnatch_vrfs` here.

This is a temporary solution to enable the Verifiable team to continue their work without delays caused by unresolved cryptographic dependencies.