### PR TITLE
Add alias derivation function

### DIFF
--- a/src/demo_impls.rs
+++ b/src/demo_impls.rs
@@ -79,6 +79,10 @@ impl GenerateVerifiable for Trivial {
 		}
 	}
 
+	fn alias_in_context(secret: &Self::Secret, _context: &[u8]) -> Result<Alias, ()> {
+		Ok(secret.clone())
+	}
+
 	fn external_member(value: &Self::InternalMember) -> Self::Member {
 		value.clone()
 	}
@@ -175,6 +179,10 @@ impl GenerateVerifiable for Simple {
 				.map(|_| proof.1.clone())
 				.map_err(|_| ())
 		})
+	}
+
+	fn alias_in_context(secret: &Self::Secret, _context: &[u8]) -> Result<Alias, ()> {
+		Ok(Self::member_from_secret(&secret))
 	}
 
 	fn external_member(value: &Self::InternalMember) -> Self::Member {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,9 @@ pub trait GenerateVerifiable {
 		}
 	}
 
+	/// Generate the alias a `secret` would have in a given `context`.
+	fn alias_in_context(secret: &Self::Secret, context: &[u8]) -> Result<Alias, ()>;
+
 	/// Like `is_valid`, but `alias` is returned, not provided.
 	fn validate(
 		_proof: &Self::Proof,


### PR DESCRIPTION
This PR adds a function to generate the alias that is derived for a keypair in a given context.

Right now the only way to generate the alias is to generate a proof as well through thewaste the `open` into `create` flow. This wastes a lot of compute for the cases where the alias is relevant before the member set is known.