### PR TITLE
Derive decode with mem tracking for types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 derive-where = "1.2"
 bounded-collections = { version = "0.1.8", default-features = false }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive","max-encoded-len"] }
+parity-scale-codec = { version = "3.7.4", default-features = false, features = ["derive","max-encoded-len"] }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.10.2", default-features = false, features = ["u64_backend"] }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }

--- a/src/demo_impls.rs
+++ b/src/demo_impls.rs
@@ -95,7 +95,9 @@ impl GenerateVerifiable for Trivial {
 const SIG_CON: &[u8] = b"verifiable";
 
 /// Example impl of `Verifiable` which uses Schnorrkel. This doesn't anonymise anything.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen, DecodeWithMemTracking,
+)]
 pub struct Simple;
 impl GenerateVerifiable for Simple {
 	type Members = BoundedVec<Self::Member, ConstU32<1024>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate core;
 use alloc::vec::Vec;
 
 use core::fmt::Debug;
-use parity_scale_codec::{Decode, Encode, FullCodec, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use scale_info::*;
 
 pub mod demo_impls;
@@ -179,7 +179,7 @@ pub trait GenerateVerifiable {
 }
 
 // This is just a convenience struct to help manage some of the witness data. No need to look at it.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, DecodeWithMemTracking)]
 pub struct Receipt<Gen: GenerateVerifiable> {
 	proof: Gen::Proof,
 	alias: Alias,

--- a/src/ring_vrf_impl.rs
+++ b/src/ring_vrf_impl.rs
@@ -132,7 +132,9 @@ impl BandersnatchVrfVerifiable {
 	}
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen, DecodeWithMemTracking,
+)]
 pub struct EncodedPublicKey(pub [u8; PUBLIC_KEY_LENGTH]);
 
 impl GenerateVerifiable for BandersnatchVrfVerifiable {


### PR DESCRIPTION
update parity-scale-codec to 3.7.4 and derive `DecodeWithMemTracking`.

This is needed because FRAME will soon require call to implement `DecodeWithMemTracking`.

cc @georgepisaltu 