### PR TITLE
Implement multiple member pushing

### DIFF
--- a/src/demo_impls.rs
+++ b/src/demo_impls.rs
@@ -31,6 +31,16 @@ impl GenerateVerifiable for Trivial {
 	) -> Result<(), ()> {
 		inter.try_push(who).map_err(|_| ())
 	}
+	fn push_members(
+		inter: &mut Self::Intermediate,
+		members: impl Iterator<Item = Self::Member>,
+		_chunks: &[Self::StaticChunk],
+	) -> Result<(), ()> {
+		for member in members {
+			inter.try_push(member).map_err(|_| ())?
+		}
+		Ok(())
+	}
 	fn finish_members(inter: Self::Intermediate) -> Self::Members {
 		inter
 	}
@@ -132,6 +142,16 @@ impl GenerateVerifiable for Simple {
 		_lookup: impl Fn(usize) -> Result<Self::StaticChunk, ()>,
 	) -> Result<(), ()> {
 		inter.try_push(who).map_err(|_| ())
+	}
+	fn push_members(
+		inter: &mut Self::Intermediate,
+		members: impl Iterator<Item = Self::Member>,
+		_chunks: &[Self::StaticChunk],
+	) -> Result<(), ()> {
+		for member in members {
+			inter.try_push(member).map_err(|_| ())?
+		}
+		Ok(())
 	}
 	fn finish_members(inter: Self::Intermediate) -> Self::Members {
 		inter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,10 @@ pub trait GenerateVerifiable {
 	fn start_members() -> Self::Intermediate;
 
 	/// Introduce a set of new `Member`s into the intermediate value used to build a new `Members`
-	/// value. This function is especially suitable for low domain sizes, as the provided `chunks`
-	/// must be the whole set of chunks available for a domain, such that a lookup `chunks[i]` would
-	/// yield the corresponding chunk for the `i`th key in the intermediate.
+	/// value.
+	///
+	/// An error is returned if at least one member failed to be pushed. This can happen if the
+	/// maximum capacity has already been reached or the member is already part of the set.
 	fn push_members(
 		intermediate: &mut Self::Intermediate,
 		members: impl Iterator<Item = Self::Member>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,23 @@ pub trait GenerateVerifiable {
 		who: Self::Member,
 		lookup: impl Fn(usize) -> Result<Self::StaticChunk, ()>,
 	) -> Result<(), ()>;
-	// push_members
+
+	/// Introduce a set of new `Member`s into the intermediate value used to build a new `Members`
+	/// value. This function is especially suitable for low domain sizes, as the provided `chunks`
+	/// must be the whole set of chunks available for a domain, such that a lookup `chunks[i]` would
+	/// yield the corresponding chunk for the `i`th key in the intermediate.
+	fn push_members(
+		intermediate: &mut Self::Intermediate,
+		members: impl Iterator<Item = Self::Member>,
+		chunks: &[Self::StaticChunk],
+	) -> Result<(), ()> {
+		let lookup = |chunk_idx| chunks.get(chunk_idx).cloned().ok_or(());
+		for member in members {
+			Self::push_member(intermediate, member, &lookup)?
+		}
+		Ok(())
+	}
+
 	/// Consume the `intermediate` value to create a new `Members` value.
 	fn finish_members(inter: Self::Intermediate) -> Self::Members;
 


### PR DESCRIPTION
As the title says, this PR implements a batch operation for `push_member`. This speeds up the process of building a ring when the keys are known in advance. It also makes chunk fetching more friendly to caching.