### PR TITLE
add is member valid function to easily check the validity of a member

### DIFF
--- a/src/demo_impls.rs
+++ b/src/demo_impls.rs
@@ -19,6 +19,10 @@ impl GenerateVerifiable for Trivial {
 	type Signature = [u8; 32];
 	type StaticChunk = ();
 
+	fn is_member_valid(_member: &Self::Member) -> bool {
+		true
+	}
+
 	fn start_members() -> Self::Intermediate {
 		BoundedVec::new()
 	}
@@ -114,6 +118,10 @@ impl GenerateVerifiable for Simple {
 	type Proof = ([u8; 64], Alias);
 	type Signature = [u8; 64];
 	type StaticChunk = ();
+
+	fn is_member_valid(_member: &Self::Member) -> bool {
+		true
+	}
 
 	fn start_members() -> Self::Intermediate {
 		BoundedVec::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,12 @@ pub trait GenerateVerifiable {
 	/// Introduce a set of new `Member`s into the intermediate value used to build a new `Members`
 	/// value.
 	///
-	/// An error is returned if at least one member failed to be pushed. This can happen if the
-	/// maximum capacity has already been reached or the member is already part of the set.
+	/// An error is returned if at least one member failed to be pushed. This happens in those
+	/// situations:
+	/// * the maximum capacity has already been reached
+	/// * the member is already part of the set
+	/// * the member is invalid (can be checked with `is_member_valid`)
+	/// * the lookup function is invalid
 	fn push_members(
 		intermediate: &mut Self::Intermediate,
 		members: impl Iterator<Item = Self::Member>,
@@ -103,6 +107,9 @@ pub trait GenerateVerifiable {
 	/// `Secret` for `member` and as such is practical to conduct on an offline/air-gapped device.
 	///
 	/// NOTE: We never expect to use this code on-chain; it should be used only in the wallet.
+	///
+	/// **WARNING**: This function may panic if called from on-chain or an environment not
+	/// implementing the functionality.
 	fn open(
 		member: &Self::Member,
 		members_iter: impl Iterator<Item = Self::Member>,
@@ -120,6 +127,9 @@ pub trait GenerateVerifiable {
 	/// are unlinkable.
 	///
 	/// NOTE: We never expect to use this code on-chain; it should be used only in the wallet.
+	///
+	/// **WARNING**: This function may panic if called from on-chain or an environment not
+	/// implementing the functionality.
 	fn create(
 		commitment: Self::Commitment,
 		secret: &Self::Secret,
@@ -168,6 +178,8 @@ pub trait GenerateVerifiable {
 	) -> bool {
 		false
 	}
+
+	fn is_member_valid(_member: &Self::Member) -> bool;
 }
 
 // This is just a convenience struct to help manage some of the witness data. No need to look at it.

--- a/src/ring_vrf_impl.rs
+++ b/src/ring_vrf_impl.rs
@@ -384,6 +384,10 @@ impl GenerateVerifiable for BandersnatchVrfVerifiable {
 		let alias = make_alias(&output);
 		Ok(alias)
 	}
+
+	fn is_member_valid(member: &Self::Member) -> bool {
+		Self::to_public_key(member).is_ok()
+	}
 }
 
 #[cfg(test)]
@@ -793,5 +797,18 @@ mod tests {
 		);
 
 		assert_eq!(inter1, inter2);
+	}
+
+	#[test]
+	fn test_is_member_valid_invalid() {
+		let invalid_member = EncodedPublicKey([0; 32]);
+		assert!(!BandersnatchVrfVerifiable::is_member_valid(&invalid_member));
+	}
+
+	#[test]
+	fn test_is_member_valid_valid() {
+		let secret = BandersnatchVrfVerifiable::new_secret([42u8; 32]);
+		let valid_member = BandersnatchVrfVerifiable::member_from_secret(&secret);
+		assert!(BandersnatchVrfVerifiable::is_member_valid(&valid_member));
 	}
 }


### PR DESCRIPTION
Another implementation would be to reintroduce `internal_member` and require the `internal_member` as input of `push_members`.

But this is also ok.