### PR TITLE
Avoid heap alloc for single-context proofs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 exclude = ["src/ring/data/bls12-381/zcash-srs-2-16-uncompressed.bin"]
 
 [dependencies]
-bounded-collections = { version = "0.1.8", default-features = false, optional = true }
+bounded-collections = { version = "0.1.8", default-features = false }
 parity-scale-codec = { version = "3.7.4", default-features = false, features = ["derive","max-encoded-len"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
@@ -31,7 +31,7 @@ path = "utils/generate_test_keys.rs"
 default = ["std"]
 std = [
     "prover",
-    "bounded-collections?/std",
+    "bounded-collections/std",
     "parity-scale-codec/std",
     "scale-info/std",
     "ark-serialize/std",
@@ -51,4 +51,4 @@ no-std-prover = [
     "prover",
     "ark-vrf/test-vectors",
 ]
-testing = ["bounded-collections"]
+testing = []

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -9,6 +9,7 @@ use super::*;
 use bounded_collections::{BoundedVec, ConstU32};
 
 const MAX_MEMBERS: u32 = 1024;
+const MAX_CONTEXTS: u32 = 16;
 
 /// [`Capacity`] impl for the simple demo (no ring VRF).
 impl Capacity for () {
@@ -36,7 +37,7 @@ fn simple_alias(secret: &[u8; 32], context: &[u8]) -> Alias {
 }
 
 /// Proof for [`Simple`]: a tuple of (member, aliases) where aliases are one per context.
-pub type SimpleProof = ([u8; 32], Vec<Alias>);
+pub type SimpleProof = ([u8; 32], BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>);
 
 /// Toy [`Verifiable`] implementation.
 ///
@@ -113,7 +114,8 @@ impl Verifiable for Simple {
 			.iter()
 			.map(|ctx| simple_alias(secret, ctx))
 			.collect();
-		Ok(((member, aliases.clone()), aliases))
+		let bounded_aliases = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
+		Ok(((member, bounded_aliases), aliases))
 	}
 
 	fn validate_multi_context(
@@ -130,21 +132,9 @@ impl Verifiable for Simple {
 		if aliases.len() != contexts.len() {
 			return Err(());
 		}
-		Ok(aliases.clone())
+		Ok(aliases.to_vec())
 	}
 
-	fn batch_validate(
-		capacity: Self::Capacity,
-		members: &Self::Members,
-		proofs: &[BatchProofItem<Self::Proof>],
-	) -> Result<Vec<Alias>, ()> {
-		proofs
-			.iter()
-			.map(|item| {
-				Self::validate(capacity, &item.proof, members, &item.context, &item.message)
-			})
-			.collect()
-	}
 
 	fn alias_in_context(secret: &Self::Secret, context: &[u8]) -> Result<Alias, ()> {
 		Ok(simple_alias(secret, context))

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -135,7 +135,6 @@ impl Verifiable for Simple {
 		Ok(aliases.to_vec())
 	}
 
-
 	fn alias_in_context(secret: &Self::Secret, context: &[u8]) -> Result<Alias, ()> {
 		Ok(simple_alias(secret, context))
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,14 +258,24 @@ pub trait Verifiable {
 
 	/// Check whether all of the proofs in this batch are valid, returning the `Alias` for each one,
 	/// in order of input.
+	///
+	/// Currently only supports single-context proofs. Multi-context proofs should be
+	/// validated individually via [`Self::validate_multi_context`].
 	fn batch_validate(
 		capacity: Self::Capacity,
 		members: &Self::Members,
 		proofs: &[BatchProofItem<Self::Proof>],
-	) -> Result<Vec<Alias>, ()>;
+	) -> Result<Vec<Alias>, ()> {
+		proofs
+			.iter()
+			.map(|item| {
+				Self::validate(capacity, &item.proof, members, &item.context, &item.message)
+			})
+			.collect()
+	}
 
 	/// Check whether `member` is a valid encoded public key for this scheme.
-	fn is_member_valid(_member: &Self::Member) -> bool;
+	fn is_member_valid(member: &Self::Member) -> bool;
 
 	/// Make a non-anonymous signature of `message` using `secret`.
 	fn sign(secret: &Self::Secret, message: &[u8]) -> Result<Self::Signature, ()>;

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -38,6 +38,9 @@ impl RingSuiteExt for ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 {
 	const MEMBERS_COMMITMENT_SIZE: usize = 768;
 	const STATIC_CHUNK_SIZE: usize = 96;
 	const SIGNATURE_SIZE: usize = 48;
+	const RING_PROOF_SIZE: usize = 752;
+	const VRF_OUTPUT_SIZE: usize = 32;
+	const MAX_VRF_CONTEXTS: u8 = 16;
 
 	type CurveParams = Bls12_381Params;
 
@@ -55,7 +58,7 @@ mod tests {
 	use ark_vrf::ring::SrsLookup;
 
 	use super::*;
-	use crate::{ring::RingSize, Capacity, Verifiable};
+	use crate::{ring::{ring_signature_size, RingSize}, Capacity, Verifiable};
 
 	// Type aliases for Bandersnatch-specific generic types
 	pub type MembersSet = crate::ring::MembersSet<BandersnatchSha512Ell2>;
@@ -151,6 +154,49 @@ mod tests {
 		// SIGNATURE_SIZE
 		let signature = BandersnatchVrfVerifiable::sign(&secret, b"test").unwrap();
 		assert_eq!(signature.len(), S::SIGNATURE_SIZE);
+	}
+
+	/// Verify that proof sizes match the `RingSuiteExt` size constants.
+	#[cfg(feature = "prover")]
+	#[test]
+	fn proof_size_check() {
+		use ark_serialize::Compress;
+		type S = BandersnatchSha512Ell2;
+
+		let capacity: crate::ring::RingSize<S> = RingDomainSize::Domain11.into();
+		let secrets: Vec<_> = (0..3)
+			.map(|i| BandersnatchVrfVerifiable::new_secret([i; 32]))
+			.collect();
+		let member_keys: Vec<_> = secrets
+			.iter()
+			.map(BandersnatchVrfVerifiable::member_from_secret)
+			.collect();
+
+		let commitment =
+			BandersnatchVrfVerifiable::open(capacity, &member_keys[0], member_keys.iter().cloned())
+				.unwrap();
+
+		// Single context: verify raw bytes match RING_PROOF_SIZE + 1 + VRF_OUTPUT_SIZE
+		let (proof, _) =
+			BandersnatchVrfVerifiable::create(commitment.clone(), &secrets[0], b"ctx", b"msg")
+				.unwrap();
+		assert_eq!(proof.len(), ring_signature_size::<S>(1));
+
+		// Deserialize and verify serialized_size matches the raw length
+		let signature =
+			crate::ring::RingVrfSignature::<S>::deserialize_compressed(proof.as_slice()).unwrap();
+		assert_eq!(signature.serialized_size(Compress::Yes), proof.len());
+
+		// Multi context (3): verify the size scales with VRF_OUTPUT_SIZE per context
+		let contexts: Vec<&[u8]> = vec![b"a", b"b", b"c"];
+		let (proof_multi, _) = BandersnatchVrfVerifiable::create_multi_context(
+			commitment,
+			&secrets[0],
+			&contexts,
+			b"msg",
+		)
+		.unwrap();
+		assert_eq!(proof_multi.len(), ring_signature_size::<S>(3));
 	}
 }
 
@@ -837,6 +883,40 @@ mod builder_tests {
 		);
 
 		assert_eq!(inter1, inter2);
+	});
+
+	test_for_all_domains!(empty_context_works, |domain_size| {
+		let capacity: RingSize = domain_size.into();
+
+		let _ = bandersnatch_ring_prover_params(domain_size);
+
+		let secrets: Vec<_> = (0..3)
+			.map(|i| BandersnatchVrfVerifiable::new_secret([i as u8; 32]))
+			.collect();
+		let member_keys: Vec<_> = secrets
+			.iter()
+			.map(BandersnatchVrfVerifiable::member_from_secret)
+			.collect();
+		let commitment =
+			BandersnatchVrfVerifiable::open(capacity, &member_keys[0], member_keys.iter().cloned())
+				.unwrap();
+		let members = build_members(member_keys.iter().copied(), domain_size);
+
+		let contexts: [&[u8]; 0] = [];
+		let message = b"Message";
+
+		let (proof, aliases) = BandersnatchVrfVerifiable::create_multi_context(
+			commitment,
+			&secrets[0],
+			&contexts,
+			message,
+		)
+		.unwrap();
+
+		assert!(aliases.is_empty());
+		assert!(BandersnatchVrfVerifiable::is_valid_multi_context(
+			capacity, &proof, &members, &contexts, &aliases, message,
+		));
 	});
 
 	test_for_all_domains!(multi_context_works, |domain_size| {

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -58,7 +58,10 @@ mod tests {
 	use ark_vrf::ring::SrsLookup;
 
 	use super::*;
-	use crate::{ring::{ring_signature_size, RingSize}, Capacity, Verifiable};
+	use crate::{
+		ring::{ring_signature_size, RingSize},
+		Capacity, Verifiable,
+	};
 
 	// Type aliases for Bandersnatch-specific generic types
 	pub type MembersSet = crate::ring::MembersSet<BandersnatchSha512Ell2>;

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -263,7 +263,6 @@ pub trait RingSuiteExt: RingSuite + Debug + 'static {
 	/// Cache strategy for ring proof params.
 	#[cfg(feature = "prover")]
 	type ParamsCache: RingProofParamsCache<Self>;
-
 }
 
 /// Serialized ring VRF signature size for a given number of contexts.
@@ -474,7 +473,10 @@ impl<S: RingSuiteExt> CanonicalSerialize for RingVrfOutputs<S> {
 
 	fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
 		let slice = self.as_slice();
-		let item_size = slice.iter().next().map_or(0, |o| o.serialized_size(compress));
+		let item_size = slice
+			.iter()
+			.next()
+			.map_or(0, |o| o.serialized_size(compress));
 		1 + slice.len() * item_size
 	}
 }

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -3,11 +3,12 @@ use core::{marker::PhantomData, ops::Deref, ops::Range};
 
 pub use ark_vrf;
 
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_vrf::{
 	ring::{RingSuite, Verifier},
 	VrfIo,
 };
+use bounded_collections::{BoundedVec, Get};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
@@ -242,8 +243,14 @@ pub trait RingSuiteExt: RingSuite + Debug + 'static {
 	const MEMBERS_COMMITMENT_SIZE: usize;
 	/// Encoded size of StaticChunk (G1 point).
 	const STATIC_CHUNK_SIZE: usize;
-	/// Encoded size of Signature
+	/// Encoded size of Signature.
 	const SIGNATURE_SIZE: usize;
+	/// Compressed size of `ark_vrf::ring::Proof<S>`.
+	const RING_PROOF_SIZE: usize;
+	/// Compressed size of a single `ark_vrf::Output<S>`.
+	const VRF_OUTPUT_SIZE: usize;
+	/// Maximum number of VRF contexts in a multi-context proof.
+	const MAX_VRF_CONTEXTS: u8;
 
 	/// Byte array type for encoded public keys.
 	type PublicKeyBytes: FixedBytes;
@@ -256,6 +263,23 @@ pub trait RingSuiteExt: RingSuite + Debug + 'static {
 	/// Cache strategy for ring proof params.
 	#[cfg(feature = "prover")]
 	type ParamsCache: RingProofParamsCache<Self>;
+
+}
+
+/// Serialized ring VRF signature size for a given number of contexts.
+pub const fn ring_signature_size<S: RingSuiteExt>(contexts_count: u8) -> usize {
+	S::RING_PROOF_SIZE + 1 + contexts_count as usize * S::VRF_OUTPUT_SIZE
+}
+
+/// [`Get<u32>`] implementation that computes the maximum proof byte length for a suite.
+///
+/// Used as the bound for `BoundedVec<u8, MaxRingVrfSignatureLen<S>>`.
+pub struct MaxRingVrfSignatureLen<S: RingSuiteExt>(PhantomData<S>);
+
+impl<S: RingSuiteExt> Get<u32> for MaxRingVrfSignatureLen<S> {
+	fn get() -> u32 {
+		ring_signature_size::<S>(S::MAX_VRF_CONTEXTS) as u32
+	}
 }
 
 macro_rules! impl_common_traits {
@@ -406,10 +430,90 @@ impl<S: RingSuiteExt> core::fmt::Debug for ProverState<S> {
 	}
 }
 
+/// VRF outputs within a ring signature.
+///
+/// For the common single-context case, the output is stored inline on the stack.
+/// For multi-context proofs, outputs are heap-allocated.
+///
+/// The wire format uses a `u8` length prefix followed by the outputs (no enum
+/// discriminant). On deserialization, length == 1 produces `Single`, length > 1
+/// produces `Multi`.
+enum RingVrfOutputs<S: RingSuiteExt> {
+	Single(ark_vrf::Output<S>),
+	Multi(Vec<ark_vrf::Output<S>>),
+}
+
+impl<S: RingSuiteExt> RingVrfOutputs<S> {
+	fn as_slice(&self) -> &[ark_vrf::Output<S>] {
+		match self {
+			Self::Single(o) => core::slice::from_ref(o),
+			Self::Multi(v) => v.as_slice(),
+		}
+	}
+}
+
+impl<S: RingSuiteExt> ark_serialize::Valid for RingVrfOutputs<S> {
+	fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+		ark_vrf::Output::<S>::batch_check(self.as_slice().iter())
+	}
+}
+
+impl<S: RingSuiteExt> CanonicalSerialize for RingVrfOutputs<S> {
+	fn serialize_with_mode<W: ark_serialize::Write>(
+		&self,
+		mut writer: W,
+		compress: ark_serialize::Compress,
+	) -> Result<(), ark_serialize::SerializationError> {
+		let slice = self.as_slice();
+		(slice.len() as u8).serialize_with_mode(&mut writer, compress)?;
+		for output in slice {
+			output.serialize_with_mode(&mut writer, compress)?;
+		}
+		Ok(())
+	}
+
+	fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+		let slice = self.as_slice();
+		let item_size = slice.iter().next().map_or(0, |o| o.serialized_size(compress));
+		1 + slice.len() * item_size
+	}
+}
+
+impl<S: RingSuiteExt> CanonicalDeserialize for RingVrfOutputs<S> {
+	fn deserialize_with_mode<R: ark_serialize::Read>(
+		mut reader: R,
+		compress: ark_serialize::Compress,
+		validate: ark_serialize::Validate,
+	) -> Result<Self, ark_serialize::SerializationError> {
+		let len = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+		if len > S::MAX_VRF_CONTEXTS {
+			return Err(ark_serialize::SerializationError::InvalidData);
+		}
+		if len == 1 {
+			let output =
+				ark_vrf::Output::<S>::deserialize_with_mode(&mut reader, compress, validate)?;
+			Ok(Self::Single(output))
+		} else {
+			let mut outputs = Vec::with_capacity(len as usize);
+			for _ in 0..len {
+				outputs.push(ark_vrf::Output::<S>::deserialize_with_mode(
+					&mut reader,
+					compress,
+					ark_serialize::Validate::No,
+				)?);
+			}
+			if let ark_serialize::Validate::Yes = validate {
+				ark_vrf::Output::<S>::batch_check(outputs.iter())?;
+			}
+			Ok(Self::Multi(outputs))
+		}
+	}
+}
+
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 struct RingVrfSignature<S: RingSuiteExt> {
 	proof: ark_vrf::ring::Proof<S>,
-	outputs: Vec<ark_vrf::Output<S>>,
+	outputs: RingVrfOutputs<S>,
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
@@ -433,7 +537,7 @@ impl<S: RingSuiteExt> Verifiable for RingVrfVerifiable<S> {
 	type Members = MembersCommitment<S>;
 	type Intermediate = MembersSet<S>;
 	type Member = S::PublicKeyBytes;
-	type Proof = Vec<u8>;
+	type Proof = BoundedVec<u8, MaxRingVrfSignatureLen<S>>;
 	type Signature = S::SignatureBytes;
 	type StaticChunk = StaticChunk<S>;
 	type Capacity = RingSize<S>;
@@ -497,15 +601,17 @@ impl<S: RingSuiteExt> Verifiable for RingVrfVerifiable<S> {
 			capacity.size(),
 		);
 
-		let signature = RingVrfSignature::<S>::deserialize_compressed(&**proof).map_err(|_| ())?;
+		let signature =
+			RingVrfSignature::<S>::deserialize_compressed(proof.as_slice()).map_err(|_| ())?;
 
-		if contexts.len() != signature.outputs.len() {
+		let outputs = signature.outputs.as_slice();
+		if contexts.len() != outputs.len() {
 			return Err(());
 		}
 
 		let (ios, aliases): (Vec<_>, Vec<_>) = contexts
 			.iter()
-			.zip(signature.outputs)
+			.zip(outputs.iter().copied())
 			.map(|(ctx, output)| {
 				let input_msg = [S::VRF_INPUT_DOMAIN, ctx].concat();
 				let input = ark_vrf::Input::<S>::new(&input_msg[..]).expect("H2C can't fail here");
@@ -543,13 +649,13 @@ impl<S: RingSuiteExt> Verifiable for RingVrfVerifiable<S> {
 		{
 			let input_msg = [S::VRF_INPUT_DOMAIN, context.as_slice()].concat();
 			let input = ark_vrf::Input::<S>::new(&input_msg[..]).expect("H2C can't fail here");
-			let signature = RingVrfSignature::<S>::deserialize_compressed_unchecked(&**proof)
-				.map_err(|_| ())?;
+			let signature =
+				RingVrfSignature::<S>::deserialize_compressed(proof.as_slice()).map_err(|_| ())?;
 
-			if signature.outputs.len() != 1 {
-				return Err(());
-			}
-			let output = signature.outputs[0];
+			let output = match signature.outputs {
+				RingVrfOutputs::Single(o) => o,
+				_ => return Err(()),
+			};
 
 			aliases.push(make_alias(&output));
 
@@ -622,11 +728,17 @@ impl<S: RingSuiteExt> Verifiable for RingVrfVerifiable<S> {
 
 		let proof = secret.prove(ios, message, &ring_prover);
 
+		let outputs = if outputs.len() == 1 {
+			RingVrfOutputs::Single(outputs.into_iter().next().unwrap())
+		} else {
+			RingVrfOutputs::Multi(outputs)
+		};
 		let signature = RingVrfSignature::<S> { outputs, proof };
 
 		let mut buf = vec![];
 		signature.serialize_compressed(&mut buf).map_err(|_| ())?;
 
+		let buf = BoundedVec::try_from(buf).map_err(|_| ())?;
 		Ok((buf, aliases))
 	}
 


### PR DESCRIPTION
Also use BoundedVec for encoded Ring Vrf Proofs with capped Outputs count