### PR TITLE
Cache verifier params via RingContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.7.4", default-features = false, features = [
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false }
-ark-vrf = { git = "https://github.com/davxy/ark-vrf", rev = "dac15b2713b9010c571c88899a48b91213d0387b", default-features = false, features = ["bandersnatch", "ring"] }
+ark-vrf = { git = "https://github.com/davxy/ark-vrf", rev = "68046829587db900c73d6552c3a389aaa02bae2a", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.7.4", default-features = false, features = [
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false }
-ark-vrf = { path = "/mnt/ssd/develop/crypto/ark-vrf", default-features = false, features = ["bandersnatch", "ring"] }
+ark-vrf = { git = "https://github.com/davxy/ark-vrf", rev = "dac15b2713b9010c571c88899a48b91213d0387b", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.7.4", default-features = false, features = [
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false }
-ark-vrf = { version = "0.4.0", default-features = false, features = ["bandersnatch", "ring"] }
+ark-vrf = { path = "/mnt/ssd/develop/crypto/ark-vrf", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 
 [dev-dependencies]

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -1,42 +1,39 @@
 #[cfg(not(feature = "prover"))]
-use crate::ring::make_ring_verifier_params;
+use crate::ring::make_ring_context;
 use crate::ring::{
-	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierParamsCache,
+	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierCache,
 };
-pub use ark_vrf::suites::bandersnatch::{BandersnatchSha512Ell2, RingProofParams};
+pub use ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2;
 
 #[cfg(feature = "prover")]
-use crate::ring::{make_ring_prover_params, ProverParamsCache};
+use crate::ring::{make_ring_setup, ProverCache};
 
 /// Bandersnatch ring VRF Verifiable (BandersnatchSha512Ell2 suite).
 pub type BandersnatchVrfVerifiable = RingVrfVerifiable<BandersnatchSha512Ell2>;
 
-/// Lazy-static cache for Bandersnatch ring verifier params.
+/// Lazy-static cache for Bandersnatch ring context.
 ///
-/// Params are computed once per domain size on first access and reused thereafter.
-/// When the `prover` feature is enabled, verifier params are extracted from the
-/// prover's cached `RingProofParams`.
-pub struct BandersnatchVerifierParamsCache;
+/// Computed once per domain size on first access and reused thereafter.
+/// When the `prover` feature is enabled, the context is extracted from the
+/// cached `RingSetup`.
+pub struct BandersnatchVerifierCache;
 
-impl VerifierParamsCache<BandersnatchSha512Ell2> for BandersnatchVerifierParamsCache {
-	type Handle = &'static ark_vrf::ring::RingVerifierParams<BandersnatchSha512Ell2>;
+impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
+	type Handle = &'static ark_vrf::ring::RingContext<BandersnatchSha512Ell2>;
 
+	#[cfg(feature = "prover")]
+	fn get(domain_size: RingDomainSize) -> Self::Handle {
+		BandersnatchProverCache::get(domain_size).ring_context()
+	}
+
+	#[cfg(not(feature = "prover"))]
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
 		use spin::Once;
-		type P = ark_vrf::ring::RingVerifierParams<BandersnatchSha512Ell2>;
+		type P = ark_vrf::ring::RingContext<BandersnatchSha512Ell2>;
 		static D11: Once<P> = Once::new();
 		static D12: Once<P> = Once::new();
 		static D16: Once<P> = Once::new();
-		let init = || {
-			#[cfg(feature = "prover")]
-			{
-				BandersnatchProverParamsCache::get(domain_size).verifier_params()
-			}
-			#[cfg(not(feature = "prover"))]
-			{
-				make_ring_verifier_params(domain_size)
-			}
-		};
+		let init = || make_ring_context(domain_size);
 		match domain_size {
 			RingDomainSize::Domain11 => D11.call_once(init),
 			RingDomainSize::Domain12 => D12.call_once(init),
@@ -45,22 +42,23 @@ impl VerifierParamsCache<BandersnatchSha512Ell2> for BandersnatchVerifierParamsC
 	}
 }
 
-/// Lazy-static cache for Bandersnatch ring proof params.
+/// Lazy-static cache for Bandersnatch ring setup.
 ///
-/// Params are computed once per domain size on first access and reused thereafter.
+/// Computed once per domain size on first access and reused thereafter.
 #[cfg(feature = "prover")]
-pub struct BandersnatchProverParamsCache;
+pub struct BandersnatchProverCache;
 
 #[cfg(feature = "prover")]
-impl ProverParamsCache<BandersnatchSha512Ell2> for BandersnatchProverParamsCache {
-	type Handle = &'static ark_vrf::ring::RingProofParams<BandersnatchSha512Ell2>;
+impl ProverCache<BandersnatchSha512Ell2> for BandersnatchProverCache {
+	type Handle = &'static ark_vrf::ring::RingSetup<BandersnatchSha512Ell2>;
 
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
 		use spin::Once;
-		static D11: Once<RingProofParams> = Once::new();
-		static D12: Once<RingProofParams> = Once::new();
-		static D16: Once<RingProofParams> = Once::new();
-		let init = || make_ring_prover_params(domain_size);
+		type P = ark_vrf::ring::RingSetup<BandersnatchSha512Ell2>;
+		static D11: Once<P> = Once::new();
+		static D12: Once<P> = Once::new();
+		static D16: Once<P> = Once::new();
+		let init = || make_ring_setup(domain_size);
 		match domain_size {
 			RingDomainSize::Domain11 => D11.call_once(init),
 			RingDomainSize::Domain12 => D12.call_once(init),
@@ -86,10 +84,10 @@ impl RingSuiteExt for ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 {
 	type PublicKeyBytes = [u8; Self::PUBLIC_KEY_SIZE];
 	type SignatureBytes = [u8; Self::SIGNATURE_SIZE];
 
-	type VerifierParamsCache = BandersnatchVerifierParamsCache;
+	type VerifierCache = BandersnatchVerifierCache;
 
 	#[cfg(feature = "prover")]
-	type ProverParamsCache = BandersnatchProverParamsCache;
+	type ProverCache = BandersnatchProverCache;
 }
 
 #[cfg(test)]
@@ -111,17 +109,17 @@ mod tests {
 
 	type RingBuilderPcsParams = ark_vrf::ring::RingBuilderPcsParams<BandersnatchSha512Ell2>;
 
-	pub fn bandersnatch_ring_prover_params(
+	pub fn bandersnatch_ring_setup(
 		domain_size: RingDomainSize,
-	) -> &'static ark_vrf::suites::bandersnatch::RingProofParams {
-		<BandersnatchSha512Ell2 as RingSuiteExt>::ProverParamsCache::get(domain_size)
+	) -> &'static ark_vrf::ring::RingSetup<BandersnatchSha512Ell2> {
+		<BandersnatchSha512Ell2 as RingSuiteExt>::ProverCache::get(domain_size)
 	}
 
 	pub fn start_members_from_params(
 		domain_size: RingDomainSize,
 	) -> (MembersSet, RingBuilderPcsParams) {
 		let (builder, builder_pcs_params) =
-			bandersnatch_ring_prover_params(domain_size).verifier_key_builder();
+			bandersnatch_ring_setup(domain_size).verifier_key_builder();
 		(crate::ring::MembersSet(builder), builder_pcs_params)
 	}
 
@@ -255,7 +253,7 @@ mod builder_tests {
 	use parity_scale_codec::Encode;
 
 	use tests::{
-		bandersnatch_ring_prover_params, start_members_from_params, MembersCommitment, MembersSet,
+		bandersnatch_ring_setup, start_members_from_params, MembersCommitment, MembersSet,
 	};
 
 	pub type RingSize = crate::ring::RingSize<BandersnatchSha512Ell2>;
@@ -317,7 +315,7 @@ mod builder_tests {
 		println!("Full size: {}", buf.len());
 
 		// Use Domain16 for SRS generation (largest domain)
-		let full_params = bandersnatch_ring_prover_params(RingDomainSize::Domain16);
+		let full_params = bandersnatch_ring_setup(RingDomainSize::Domain16);
 
 		let mut buf = vec![];
 		full_params.serialize_compressed(&mut buf).unwrap();
@@ -541,7 +539,7 @@ mod builder_tests {
 		let message = b"FooBar";
 
 		let start = Instant::now();
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 		println!(
 			"* PCS params decode: {} ms",
 			(Instant::now() - start).as_millis()
@@ -631,7 +629,7 @@ mod builder_tests {
 		let num_members = 10;
 		let num_proofs = 5;
 
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 
 		// Generate members
 		let secrets: Vec<_> = (0..num_members)
@@ -733,7 +731,7 @@ mod builder_tests {
 		let context = b"Context";
 		let num_members = 5;
 
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 
 		// Generate members
 		let secrets: Vec<_> = (0..num_members)
@@ -869,7 +867,7 @@ mod builder_tests {
 
 		let capacity: RingSize = domain_size.into();
 		let start = Instant::now();
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 		println!("* KZG decode: {} ms", (Instant::now() - start).as_millis());
 
 		// Use the domain's max ring size to test at capacity
@@ -932,7 +930,7 @@ mod builder_tests {
 	test_for_all_domains!(empty_context_works, |domain_size| {
 		let capacity: RingSize = domain_size.into();
 
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 
 		let secrets: Vec<_> = (0..3)
 			.map(|i| BandersnatchVrfVerifiable::new_secret([i as u8; 32]))
@@ -966,7 +964,7 @@ mod builder_tests {
 	test_for_all_domains!(multi_context_works, |domain_size| {
 		let capacity: RingSize = domain_size.into();
 
-		let _ = bandersnatch_ring_prover_params(domain_size);
+		let _ = bandersnatch_ring_setup(domain_size);
 
 		let secrets: Vec<_> = (0..10)
 			.map(|i| BandersnatchVrfVerifiable::new_secret([i as u8; 32]))

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -1,20 +1,58 @@
-use crate::ring::{Bls12_381Params, RingSuiteExt, RingVrfVerifiable};
+#[cfg(not(feature = "prover"))]
+use crate::ring::make_ring_verifier_params;
+use crate::ring::{
+	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierParamsCache,
+};
 pub use ark_vrf::suites::bandersnatch::{BandersnatchSha512Ell2, RingProofParams};
 
 #[cfg(feature = "prover")]
-use crate::ring::{make_ring_prover_params, RingDomainSize, RingProofParamsCache};
+use crate::ring::{make_ring_prover_params, ProverParamsCache};
 
 /// Bandersnatch ring VRF Verifiable (BandersnatchSha512Ell2 suite).
 pub type BandersnatchVrfVerifiable = RingVrfVerifiable<BandersnatchSha512Ell2>;
+
+/// Lazy-static cache for Bandersnatch ring verifier params.
+///
+/// Params are computed once per domain size on first access and reused thereafter.
+/// When the `prover` feature is enabled, verifier params are extracted from the
+/// prover's cached `RingProofParams`.
+pub struct BandersnatchVerifierParamsCache;
+
+impl VerifierParamsCache<BandersnatchSha512Ell2> for BandersnatchVerifierParamsCache {
+	type Handle = &'static ark_vrf::ring::RingVerifierParams<BandersnatchSha512Ell2>;
+
+	fn get(domain_size: RingDomainSize) -> Self::Handle {
+		use spin::Once;
+		type P = ark_vrf::ring::RingVerifierParams<BandersnatchSha512Ell2>;
+		static D11: Once<P> = Once::new();
+		static D12: Once<P> = Once::new();
+		static D16: Once<P> = Once::new();
+		let init = || {
+			#[cfg(feature = "prover")]
+			{
+				BandersnatchProverParamsCache::get(domain_size).verifier_params()
+			}
+			#[cfg(not(feature = "prover"))]
+			{
+				make_ring_verifier_params(domain_size)
+			}
+		};
+		match domain_size {
+			RingDomainSize::Domain11 => D11.call_once(init),
+			RingDomainSize::Domain12 => D12.call_once(init),
+			RingDomainSize::Domain16 => D16.call_once(init),
+		}
+	}
+}
 
 /// Lazy-static cache for Bandersnatch ring proof params.
 ///
 /// Params are computed once per domain size on first access and reused thereafter.
 #[cfg(feature = "prover")]
-pub struct BandersnatchParamsCache;
+pub struct BandersnatchProverParamsCache;
 
 #[cfg(feature = "prover")]
-impl RingProofParamsCache<BandersnatchSha512Ell2> for BandersnatchParamsCache {
+impl ProverParamsCache<BandersnatchSha512Ell2> for BandersnatchProverParamsCache {
 	type Handle = &'static ark_vrf::ring::RingProofParams<BandersnatchSha512Ell2>;
 
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
@@ -22,10 +60,11 @@ impl RingProofParamsCache<BandersnatchSha512Ell2> for BandersnatchParamsCache {
 		static D11: Once<RingProofParams> = Once::new();
 		static D12: Once<RingProofParams> = Once::new();
 		static D16: Once<RingProofParams> = Once::new();
+		let init = || make_ring_prover_params(domain_size);
 		match domain_size {
-			RingDomainSize::Domain11 => D11.call_once(|| make_ring_prover_params(domain_size)),
-			RingDomainSize::Domain12 => D12.call_once(|| make_ring_prover_params(domain_size)),
-			RingDomainSize::Domain16 => D16.call_once(|| make_ring_prover_params(domain_size)),
+			RingDomainSize::Domain11 => D11.call_once(init),
+			RingDomainSize::Domain12 => D12.call_once(init),
+			RingDomainSize::Domain16 => D16.call_once(init),
 		}
 	}
 }
@@ -47,8 +86,10 @@ impl RingSuiteExt for ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 {
 	type PublicKeyBytes = [u8; Self::PUBLIC_KEY_SIZE];
 	type SignatureBytes = [u8; Self::SIGNATURE_SIZE];
 
+	type VerifierParamsCache = BandersnatchVerifierParamsCache;
+
 	#[cfg(feature = "prover")]
-	type ParamsCache = BandersnatchParamsCache;
+	type ProverParamsCache = BandersnatchProverParamsCache;
 }
 
 #[cfg(test)]
@@ -73,7 +114,7 @@ mod tests {
 	pub fn bandersnatch_ring_prover_params(
 		domain_size: RingDomainSize,
 	) -> &'static ark_vrf::suites::bandersnatch::RingProofParams {
-		<BandersnatchSha512Ell2 as RingSuiteExt>::ParamsCache::get(domain_size)
+		<BandersnatchSha512Ell2 as RingSuiteExt>::ProverParamsCache::get(domain_size)
 	}
 
 	pub fn start_members_from_params(

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -158,16 +158,16 @@ pub const fn max_ring_size_from_domain_size<S: RingSuiteExt>(domain_size: RingDo
 	ark_vrf::ring::max_ring_size_from_pcs_domain_size::<S>(pcs_domain_size as usize)
 }
 
-/// Construct ring prover params from the suite's SRS data.
+/// Construct ring setup from the suite's SRS data.
 #[cfg(feature = "prover")]
-pub fn make_ring_prover_params<S: RingSuiteExt>(
+pub fn make_ring_setup<S: RingSuiteExt>(
 	domain_size: RingDomainSize,
-) -> ark_vrf::ring::RingProofParams<S> {
+) -> ark_vrf::ring::RingSetup<S> {
 	let data = S::CurveParams::srs_raw();
 	let pcs_params =
 		ark_vrf::ring::PcsParams::<S>::deserialize_uncompressed_unchecked(data).unwrap();
 	let ring_size = RingSize::<S>::from(domain_size).size();
-	ark_vrf::ring::RingProofParams::<S>::from_pcs_params(ring_size, pcs_params).unwrap()
+	ark_vrf::ring::RingSetup::<S>::from_pcs_params(ring_size, pcs_params).unwrap()
 }
 
 /// Get ring builder params for the given domain size.
@@ -180,34 +180,34 @@ pub fn ring_verifier_builder_params<S: RingSuiteExt>(
 	ark_vrf::ring::RingBuilderPcsParams::<S>::deserialize_uncompressed_unchecked(data).unwrap()
 }
 
-/// Construct verifier params for the given domain size.
-pub fn make_ring_verifier_params<S: RingSuiteExt>(
+/// Construct ring context for the given domain size.
+pub fn make_ring_context<S: RingSuiteExt>(
 	domain_size: RingDomainSize,
-) -> ark_vrf::ring::RingVerifierParams<S> {
+) -> ark_vrf::ring::RingContext<S> {
 	let ring_size = RingSize::<S>::from(domain_size).size();
-	ark_vrf::ring::RingVerifierParams::<S>::from_ring_size(ring_size)
+	ark_vrf::ring::RingContext::<S>::new(ring_size)
 }
 
-/// Trait for caching ring verifier params.
+/// Trait for caching ring context.
 ///
 /// The `Handle` associated type allows different caching strategies.
-pub trait VerifierParamsCache<S: RingSuiteExt> {
-	/// Handle type returned by the cache. Must deref to `RingVerifierParams<S>`.
-	type Handle: Deref<Target = ark_vrf::ring::RingVerifierParams<S>>;
+pub trait VerifierCache<S: RingSuiteExt> {
+	/// Handle type returned by the cache. Must deref to `RingContext<S>`.
+	type Handle: Deref<Target = ark_vrf::ring::RingContext<S>>;
 
-	/// Get or construct ring verifier params for the given domain size.
+	/// Get or construct ring context for the given domain size.
 	fn get(domain_size: RingDomainSize) -> Self::Handle;
 }
 
-/// Trait for caching ring proof params.
+/// Trait for caching ring setup.
 ///
 /// The `Handle` associated type allows different caching strategies.
 #[cfg(feature = "prover")]
-pub trait ProverParamsCache<S: RingSuiteExt> {
-	/// Handle type returned by the cache. Must deref to `RingProofParams<S>`.
-	type Handle: Deref<Target = ark_vrf::ring::RingProofParams<S>>;
+pub trait ProverCache<S: RingSuiteExt> {
+	/// Handle type returned by the cache. Must deref to `RingSetup<S>`.
+	type Handle: Deref<Target = ark_vrf::ring::RingSetup<S>>;
 
-	/// Get or construct ring proof params for the given domain size.
+	/// Get or construct ring setup for the given domain size.
 	fn get(domain_size: RingDomainSize) -> Self::Handle;
 }
 
@@ -215,19 +215,19 @@ pub trait ProverParamsCache<S: RingSuiteExt> {
 pub type NullCache = ();
 
 #[cfg(feature = "prover")]
-impl<S: RingSuiteExt> ProverParamsCache<S> for NullCache {
-	type Handle = alloc::boxed::Box<ark_vrf::ring::RingProofParams<S>>;
+impl<S: RingSuiteExt> ProverCache<S> for NullCache {
+	type Handle = alloc::boxed::Box<ark_vrf::ring::RingSetup<S>>;
 
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		alloc::boxed::Box::new(make_ring_prover_params::<S>(domain_size))
+		alloc::boxed::Box::new(make_ring_setup::<S>(domain_size))
 	}
 }
 
-impl<S: RingSuiteExt> VerifierParamsCache<S> for NullCache {
-	type Handle = alloc::boxed::Box<ark_vrf::ring::RingVerifierParams<S>>;
+impl<S: RingSuiteExt> VerifierCache<S> for NullCache {
+	type Handle = alloc::boxed::Box<ark_vrf::ring::RingContext<S>>;
 
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		alloc::boxed::Box::new(make_ring_verifier_params::<S>(domain_size))
+		alloc::boxed::Box::new(make_ring_context::<S>(domain_size))
 	}
 }
 
@@ -287,12 +287,12 @@ pub trait RingSuiteExt: RingSuite + Debug + 'static {
 	/// The curve static data provider for this suite.
 	type CurveParams: RingCurveParams;
 
-	/// Cache strategy for ring verifier params (prover and verifier).
-	type VerifierParamsCache: VerifierParamsCache<Self>;
+	/// Cache strategy for ring context (verifier).
+	type VerifierCache: VerifierCache<Self>;
 
-	/// Cache strategy for ring proof params (prover only).
+	/// Cache strategy for ring setup (prover).
 	#[cfg(feature = "prover")]
-	type ProverParamsCache: ProverParamsCache<Self>;
+	type ProverCache: ProverCache<Self>;
 }
 
 /// Serialized ring VRF signature size for a given number of contexts.
@@ -626,8 +626,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		contexts: &[&[u8]],
 		message: &[u8],
 	) -> Result<Vec<Alias>, ()> {
-		let verifier_params = S::VerifierParamsCache::get(capacity.dom_size);
-		let ring_verifier = verifier_params.verifier(members.0.clone());
+		let verifier_params = S::VerifierCache::get(capacity.dom_size);
+		let ring_verifier = verifier_params.ring_verifier(members.0.clone());
 
 		let signature =
 			RingVrfSignature::<S>::deserialize_compressed(proof.as_slice()).map_err(|_| ())?;
@@ -662,8 +662,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		members: &Self::Members,
 		proofs: &[BatchProofItem<Self::Proof>],
 	) -> Result<Vec<Alias>, ()> {
-		let verifier_params = S::VerifierParamsCache::get(capacity.dom_size);
-		let verifier = verifier_params.verifier(members.0.clone());
+		let verifier_params = S::VerifierCache::get(capacity.dom_size);
+		let verifier = verifier_params.ring_verifier(members.0.clone());
 
 		let mut aliases = Vec::with_capacity(proofs.len());
 		let mut batch_verifier = ark_vrf::ring::BatchVerifier::<S>::new(verifier);
@@ -709,8 +709,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 			.collect::<Result<Vec<_>, _>>()?;
 		let member = PublicKey::<S>::deserialize_compressed(member.as_ref()).map_err(|_| ())?;
 		let prover_idx = pks.iter().position(|&m| m == member.0).ok_or(())? as u32;
-		let prover_key = S::ProverParamsCache::get(capacity.dom_size)
-			.prover_key(&pks[..])
+		let prover_key = S::ProverCache::get(capacity.dom_size)
+			.prover_key(&pks)
 			.map_err(|_| ())?;
 		Ok(ProverState {
 			domain_size: capacity.dom_size.value(),
@@ -728,12 +728,13 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<(Self::Proof, Vec<Alias>), ()> {
 		use ark_vrf::ring::Prover;
 		let domain_size = RingDomainSize::try_from(commitment.domain_size).map_err(|_| ())?;
-		let params = S::ProverParamsCache::get(domain_size);
-		if commitment.prover_idx >= params.max_ring_size() as u32 {
+		let prover_params = S::ProverCache::get(domain_size);
+		if commitment.prover_idx >= prover_params.max_ring_size() as u32 {
 			return Err(());
 		}
 
-		let ring_prover = params.prover(commitment.prover_key, commitment.prover_idx as usize);
+		let ring_prover =
+			prover_params.ring_prover(commitment.prover_key, commitment.prover_idx as usize);
 
 		let (ios, aliases, outputs): (Vec<_>, Vec<_>, Vec<_>) = contexts
 			.iter()

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -98,7 +98,7 @@ impl<S: RingSuiteExt> From<RingDomainSize> for RingSize<S> {
 
 impl<S: RingSuiteExt> Capacity for RingSize<S> {
 	fn size(&self) -> usize {
-		max_ring_size_from_pcs_domain_size::<S>(self.dom_size.value())
+		max_ring_size_from_domain_size::<S>(self.dom_size)
 	}
 }
 
@@ -153,7 +153,8 @@ impl RingCurveParams for Bls12_381Params {
 }
 
 /// The max ring that can be handled for both sign/verify for the given PCS domain size.
-pub const fn max_ring_size_from_pcs_domain_size<S: RingSuiteExt>(pcs_domain_size: u32) -> usize {
+pub const fn max_ring_size_from_domain_size<S: RingSuiteExt>(domain_size: RingDomainSize) -> usize {
+	let pcs_domain_size = domain_size.value();
 	ark_vrf::ring::max_ring_size_from_pcs_domain_size::<S>(pcs_domain_size as usize)
 }
 
@@ -165,7 +166,7 @@ pub fn make_ring_prover_params<S: RingSuiteExt>(
 	let data = S::CurveParams::srs_raw();
 	let pcs_params =
 		ark_vrf::ring::PcsParams::<S>::deserialize_uncompressed_unchecked(data).unwrap();
-	let ring_size = max_ring_size_from_pcs_domain_size::<S>(domain_size.value());
+	let ring_size = RingSize::<S>::from(domain_size).size();
 	ark_vrf::ring::RingProofParams::<S>::from_pcs_params(ring_size, pcs_params).unwrap()
 }
 
@@ -179,11 +180,30 @@ pub fn ring_verifier_builder_params<S: RingSuiteExt>(
 	ark_vrf::ring::RingBuilderPcsParams::<S>::deserialize_uncompressed_unchecked(data).unwrap()
 }
 
+/// Construct verifier params for the given domain size.
+pub fn make_ring_verifier_params<S: RingSuiteExt>(
+	domain_size: RingDomainSize,
+) -> ark_vrf::ring::RingVerifierParams<S> {
+	let ring_size = RingSize::<S>::from(domain_size).size();
+	ark_vrf::ring::RingVerifierParams::<S>::from_ring_size(ring_size)
+}
+
+/// Trait for caching ring verifier params.
+///
+/// The `Handle` associated type allows different caching strategies.
+pub trait VerifierParamsCache<S: RingSuiteExt> {
+	/// Handle type returned by the cache. Must deref to `RingVerifierParams<S>`.
+	type Handle: Deref<Target = ark_vrf::ring::RingVerifierParams<S>>;
+
+	/// Get or construct ring verifier params for the given domain size.
+	fn get(domain_size: RingDomainSize) -> Self::Handle;
+}
+
 /// Trait for caching ring proof params.
 ///
 /// The `Handle` associated type allows different caching strategies.
 #[cfg(feature = "prover")]
-pub trait RingProofParamsCache<S: RingSuiteExt> {
+pub trait ProverParamsCache<S: RingSuiteExt> {
 	/// Handle type returned by the cache. Must deref to `RingProofParams<S>`.
 	type Handle: Deref<Target = ark_vrf::ring::RingProofParams<S>>;
 
@@ -191,16 +211,23 @@ pub trait RingProofParamsCache<S: RingSuiteExt> {
 	fn get(domain_size: RingDomainSize) -> Self::Handle;
 }
 
-/// Null cache: always constructs new params without caching.
-#[cfg(feature = "prover")]
+/// Null prover params cache: always constructs new params without caching.
 pub type NullCache = ();
 
 #[cfg(feature = "prover")]
-impl<S: RingSuiteExt> RingProofParamsCache<S> for NullCache {
+impl<S: RingSuiteExt> ProverParamsCache<S> for NullCache {
 	type Handle = alloc::boxed::Box<ark_vrf::ring::RingProofParams<S>>;
 
 	fn get(domain_size: RingDomainSize) -> Self::Handle {
 		alloc::boxed::Box::new(make_ring_prover_params::<S>(domain_size))
+	}
+}
+
+impl<S: RingSuiteExt> VerifierParamsCache<S> for NullCache {
+	type Handle = alloc::boxed::Box<ark_vrf::ring::RingVerifierParams<S>>;
+
+	fn get(domain_size: RingDomainSize) -> Self::Handle {
+		alloc::boxed::Box::new(make_ring_verifier_params::<S>(domain_size))
 	}
 }
 
@@ -260,9 +287,12 @@ pub trait RingSuiteExt: RingSuite + Debug + 'static {
 	/// The curve static data provider for this suite.
 	type CurveParams: RingCurveParams;
 
-	/// Cache strategy for ring proof params.
+	/// Cache strategy for ring verifier params (prover and verifier).
+	type VerifierParamsCache: VerifierParamsCache<Self>;
+
+	/// Cache strategy for ring proof params (prover only).
 	#[cfg(feature = "prover")]
-	type ParamsCache: RingProofParamsCache<Self>;
+	type ProverParamsCache: ProverParamsCache<Self>;
 }
 
 /// Serialized ring VRF signature size for a given number of contexts.
@@ -596,12 +626,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		contexts: &[&[u8]],
 		message: &[u8],
 	) -> Result<Vec<Alias>, ()> {
-		// This doesn't require the whole kzg. Thus is more appropriate if used on-chain
-		// Is a bit slower as it requires to recompute piop_params, but still in the order of ms
-		let ring_verifier = ark_vrf::ring::RingProofParams::<S>::verifier_no_context(
-			members.0.clone(),
-			capacity.size(),
-		);
+		let verifier_params = S::VerifierParamsCache::get(capacity.dom_size);
+		let ring_verifier = verifier_params.verifier(members.0.clone());
 
 		let signature =
 			RingVrfSignature::<S>::deserialize_compressed(proof.as_slice()).map_err(|_| ())?;
@@ -636,10 +662,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		members: &Self::Members,
 		proofs: &[BatchProofItem<Self::Proof>],
 	) -> Result<Vec<Alias>, ()> {
-		let verifier = ark_vrf::ring::RingProofParams::<S>::verifier_no_context(
-			members.0.clone(),
-			capacity.size(),
-		);
+		let verifier_params = S::VerifierParamsCache::get(capacity.dom_size);
+		let verifier = verifier_params.verifier(members.0.clone());
 
 		let mut aliases = Vec::with_capacity(proofs.len());
 		let mut batch_verifier = ark_vrf::ring::BatchVerifier::<S>::new(verifier);
@@ -685,7 +709,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 			.collect::<Result<Vec<_>, _>>()?;
 		let member = PublicKey::<S>::deserialize_compressed(member.as_ref()).map_err(|_| ())?;
 		let prover_idx = pks.iter().position(|&m| m == member.0).ok_or(())? as u32;
-		let prover_key = S::ParamsCache::get(capacity.dom_size)
+		let prover_key = S::ProverParamsCache::get(capacity.dom_size)
 			.prover_key(&pks[..])
 			.map_err(|_| ())?;
 		Ok(ProverState {
@@ -704,7 +728,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<(Self::Proof, Vec<Alias>), ()> {
 		use ark_vrf::ring::Prover;
 		let domain_size = RingDomainSize::try_from(commitment.domain_size).map_err(|_| ())?;
-		let params = S::ParamsCache::get(domain_size);
+		let params = S::ProverParamsCache::get(domain_size);
 		if commitment.prover_idx >= params.max_ring_size() as u32 {
 			return Err(());
 		}


### PR DESCRIPTION
Cache `RingContext` (which wraps `PiopParams`) per domain size, avoiding recomputation on every call to `validate_multi_context` and `batch_validate`.

Split the params cache into two associated types on RingSuiteExt:
    - VerifierCache (no feature gate) -- caches lightweight RingContext for verification
    - ProverCache (prover-only) -- caches full RingSetupincluding KZG SRS

The user is free to choose `NullCache`. In this case the params are recomputed (as before)


- [ ] TODO: publish ark-vrf 0.4.1 (https://github.com/davxy/ark-vrf/pull/91) to crates.io
