### PR TITLE
Fix TypeInfo generated by impl_common_traits!

### DIFF
--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -368,21 +368,18 @@ macro_rules! impl_common_traits {
 			}
 		}
 
+		impl<S: $bound> ark_scale::ArkScaleMaxEncodedLen for $type_name<S> {
+			fn max_encoded_len(_compress: ark_serialize::Compress) -> usize {
+				$size_expr
+			}
+		}
+
 		impl<S: $bound + 'static> scale_info::TypeInfo for $type_name<S> {
 			type Identity = Self;
 			fn type_info() -> scale_info::Type {
-				scale_info::Type::new(
-					scale_info::Path::new(
-						stringify!($type_name),
-						module_path!(),
-					),
-					vec![],
-					scale_info::TypeDefArray::new(
-						$size_expr as u32,
-						scale_info::MetaType::new::<u8>(),
-					),
-					vec![],
-				)
+				let mut info = <ark_scale::ArkScale<Self, { UNCOMPRESSED }>>::type_info();
+				info.path = scale_info::Path::new(stringify!($type_name), module_path!());
+				info
 			}
 		}
 

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -371,15 +371,18 @@ macro_rules! impl_common_traits {
 		impl<S: $bound + 'static> scale_info::TypeInfo for $type_name<S> {
 			type Identity = Self;
 			fn type_info() -> scale_info::Type {
-				scale_info::Type::builder()
-					.path(scale_info::Path::new(
+				scale_info::Type::new(
+					scale_info::Path::new(
 						stringify!($type_name),
 						module_path!(),
-					))
-					.composite(scale_info::build::Fields::unnamed().field(|f| {
-						f.ty::<alloc::vec::Vec<u8>>()
-							.type_name(stringify!($type_name))
-					}))
+					),
+					vec![],
+					scale_info::TypeDefArray::new(
+						$size_expr as u32,
+						scale_info::MetaType::new::<u8>(),
+					),
+					vec![],
+				)
 			}
 		}
 


### PR DESCRIPTION
```
The TypeInfo impl generated by impl_common_traits! declared the
affected types as a composite struct wrapping Vec<u8>, which tells
metadata-based decoders to expect a Compact<u32> length prefix
followed by bytes.

The Encode impl (via ark_scale::ArkScaleRef) writes raw bytes with
no length prefix, so PJS fails when decoding:
    Compact input is > Number.MAX_SAFE_INTEGER

Delegate to ArkScale's TypeInfo so the type metadata matches the
actual encoding.
```