### PR TITLE
Improve ~demo~ mock impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ All notable changes to this project will be documented in this file.
   - `create` and `validate` are now provided methods delegating to their multi-context counterparts
   - Plain signatures use IETF VRF proof directly (no VRF output), reducing signature size from 96 to 48 bytes
   - Removed `schnorrkel` dependency
-  - Replaced `Simple` (schnorrkel) and `Trivial` demo implementations with a new dependency-free `Simple` demo
-  - Demo module now gated behind the `testing` feature
+  - Replaced `Simple` (schnorrkel) and `Trivial` mock implementations with a new dependency-free `Mock` impl in the `mock` module
+  - `mock` module gated behind the `mock` feature
 - **Use uncompressed-unchecked codec for trusted domain types** ([#34](https://github.com/paritytech/verifiable/pull/34))
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ark-serialize = { version = "0.5", default-features = false, features = ["derive
 ark-scale = { version = "0.0.13", default-features = false }
 ark-vrf = { version = "0.5.0", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
+sha2 = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["getrandom"] }
@@ -38,6 +39,7 @@ std = [
     "ark-scale/std",
     "ark-vrf/std",
     "ark-vrf/parallel",
+    "sha2?/std",
 ]
 # Include ring builder params binary data for building ring commitments.
 # Disable this feature to reduce library size in production environments
@@ -51,4 +53,4 @@ no-std-prover = [
     "prover",
     "ark-vrf/test-vectors",
 ]
-testing = []
+testing = ["sha2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,7 @@ no-std-prover = [
     "prover",
     "ark-vrf/test-vectors",
 ]
-testing = ["sha2"]
+# Exposes the `mock` module with a non-cryptographic `Mock` implementation
+# of `GenerateVerifiable`. Intended as a test double for downstream crates
+# that exercise code consuming the trait without the ring-VRF machinery.
+mock = ["sha2"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ supporting up to 16127 members.
 | `prover` | Proof generation (`open`, `create`, `create_multi_context`) |
 | `builder-params` | Includes precomputed ring builder params for building ring commitments |
 | `no-std-prover` | Deterministic prover for `no_std` environments (testing only) |
-| `testing` | Exposes the `demo` module with a toy `Simple` implementation for tests |
+| `mock` | Exposes the `mock` module with a non-cryptographic `Mock` implementation for tests |
 
 For verifier-only builds (e.g. on-chain), disable default features.
 

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -20,7 +20,7 @@ use bounded_collections::{BoundedVec, ConstU32};
 use sha2::{Digest, Sha256};
 
 const MAX_MEMBERS: u32 = 1024;
-const MAX_CONTEXTS: u32 = 16;
+const MAX_CONTEXTS: u32 = 3;
 
 const TAG_ALIAS: &[u8] = b"verifiable-demo:v1:alias";
 const TAG_SIG: &[u8] = b"verifiable-demo:v1:sig";

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -72,7 +72,7 @@ fn make_proof_tag(
 
 /// Proof for [`Simple`]. The `tag` is a hash that binds the member, contexts,
 /// aliases, and message together; the verifier recomputes it and compares.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[derive(Default, Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, Debug, TypeInfo)]
 pub struct SimpleProof {
 	pub tag: [u8; 32],
 	pub member: [u8; 32],

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -52,12 +52,7 @@ fn alias_for(secret: &[u8; 32], context: &[u8]) -> Alias {
 
 /// Tag binding the prover (`member`), the contexts, the resulting aliases,
 /// and the message. The verifier reconstructs the same tag and compares.
-fn proof_tag(
-	member: &[u8; 32],
-	contexts: &[&[u8]],
-	aliases: &[Alias],
-	message: &[u8],
-) -> [u8; 32] {
+fn proof_tag(member: &[u8; 32], contexts: &[&[u8]], aliases: &[Alias], message: &[u8]) -> [u8; 32] {
 	let mut hasher = Sha256::new();
 	hasher.update(TAG_PROOF);
 	hasher.update(member);
@@ -75,13 +70,14 @@ fn proof_tag(
 	hasher.finalize().into()
 }
 
-/// Proof for [`Simple`]: `(member, aliases, tag)` where `tag` is a hash that
-/// binds the member, contexts, aliases, and message together.
-pub type SimpleProof = (
-	[u8; 32],
-	BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>,
-	[u8; 32],
-);
+/// Proof for [`Simple`]. The `tag` is a hash that binds the member, contexts,
+/// aliases, and message together; the verifier recomputes it and compares.
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+pub struct SimpleProof {
+	pub tag: [u8; 32],
+	pub member: [u8; 32],
+	pub aliases: BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>,
+}
 
 /// Toy [`GenerateVerifiable`] implementation.
 #[derive(Debug)]
@@ -98,7 +94,7 @@ impl GenerateVerifiable for Simple {
 	type StaticChunk = ();
 	type Capacity = ();
 
-	fn start_members(_capacity: ()) -> Self::Intermediate {
+	fn start_members(_capacity: Self::Capacity) -> Self::Intermediate {
 		BoundedVec::new()
 	}
 
@@ -130,7 +126,7 @@ impl GenerateVerifiable for Simple {
 
 	#[cfg(feature = "prover")]
 	fn open(
-		_capacity: (),
+		_capacity: Self::Capacity,
 		member: &Self::Member,
 		members: impl Iterator<Item = Self::Member>,
 	) -> Result<Self::Commitment, ()> {
@@ -157,7 +153,12 @@ impl GenerateVerifiable for Simple {
 		let aliases: Vec<Alias> = contexts.iter().map(|ctx| alias_for(secret, ctx)).collect();
 		let bounded = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
 		let tag = proof_tag(&member, contexts, &aliases, message);
-		Ok(((member, bounded, tag), aliases))
+		let proof = SimpleProof {
+			tag,
+			member,
+			aliases: bounded,
+		};
+		Ok((proof, aliases))
 	}
 
 	fn validate_multi_context(
@@ -167,7 +168,11 @@ impl GenerateVerifiable for Simple {
 		contexts: &[&[u8]],
 		message: &[u8],
 	) -> Result<Vec<Alias>, ()> {
-		let (member, aliases, tag) = proof;
+		let SimpleProof {
+			tag,
+			member,
+			aliases,
+		} = proof;
 		if !members.contains(member) {
 			return Err(());
 		}
@@ -265,7 +270,8 @@ mod tests {
 		let members = make_members(&[secret]);
 
 		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
-		let (proof, _) = Simple::create_multi_context(commitment, &secret, &[b"ctx"], b"msg").unwrap();
+		let (proof, _) =
+			Simple::create_multi_context(commitment, &secret, &[b"ctx"], b"msg").unwrap();
 
 		assert!(Simple::validate((), &proof, &members, b"ctx", b"msg").is_ok());
 		// Different message must fail.
@@ -280,7 +286,8 @@ mod tests {
 		let members = make_members(&[secret]);
 
 		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
-		let (proof, _) = Simple::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
+		let (proof, _) =
+			Simple::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
 
 		assert!(Simple::validate((), &proof, &members, b"a", b"msg").is_ok());
 		// Wrong context must fail (alias mismatch).

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,51 +1,89 @@
-//! Simple (insecure) implementation of [`GenerateVerifiable`] for illustration and testing.
+//! Toy implementation of [`GenerateVerifiable`] for tests.
 //!
-//! This module provides a toy implementation that demonstrates how to implement
-//! the trait. It has no real cryptographic properties -- the "alias" is just
-//! a hash of (secret, context) and the "proof" bundles those aliases with the
-//! member identity. Do not use in production.
+//! This is a non-cryptographic implementation: there is no anonymity (the proof
+//! reveals which member produced it), and "signatures" are trivially forgeable
+//! because the public key (`Member`) is also the private key (`Secret`). It is,
+//! however, a faithful exerciser of the trait contract -- every output is bound
+//! to all of its inputs via SHA-256 with domain-separated tags, so any test
+//! that swaps a context, message, member set, or alias produces a different
+//! result and fails verification. Use it to exercise code that consumes the
+//! trait; do not use it in production.
+//!
+//! Differences from a real ring-VRF impl:
+//! - `Member == Secret`, so anyone observing a `Member` can forge.
+//! - Aliases are deterministic per `(member, context)` and the proof carries
+//!   the `member` in the clear, so observers can link aliases back to members.
+//! - Set membership is checked by linear scan, not zero-knowledge.
 
 use super::*;
 use bounded_collections::{BoundedVec, ConstU32};
+use sha2::{Digest, Sha256};
 
 const MAX_MEMBERS: u32 = 1024;
 const MAX_CONTEXTS: u32 = 16;
 
-/// [`Capacity`] impl for the simple demo (no ring VRF).
+const TAG_ALIAS: &[u8] = b"verifiable-demo:v1:alias";
+const TAG_SIG: &[u8] = b"verifiable-demo:v1:sig";
+const TAG_PROOF: &[u8] = b"verifiable-demo:v1:proof";
+
+/// [`Capacity`] impl for the demo (no ring VRF).
 impl Capacity for () {
 	fn size(&self) -> usize {
 		MAX_MEMBERS as usize
 	}
 }
 
-fn simple_hash(data: &[&[u8]]) -> [u8; 32] {
-	// Poor man's hash: XOR-fold all input bytes into a 32-byte block.
-	// Not collision-resistant -- just enough for a demo.
-	let mut out = [0u8; 32];
-	let mut pos = 0usize;
-	for chunk in data {
-		for &byte in *chunk {
-			out[pos % 32] ^= byte;
-			pos += 1;
-		}
+/// SHA-256 with length-prefixed inputs for unambiguous concatenation.
+fn h(domain: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	hasher.update((domain.len() as u32).to_le_bytes());
+	hasher.update(domain);
+	hasher.update((parts.len() as u32).to_le_bytes());
+	for p in parts {
+		hasher.update((p.len() as u32).to_le_bytes());
+		hasher.update(p);
 	}
-	out
+	hasher.finalize().into()
 }
 
-fn simple_alias(secret: &[u8; 32], context: &[u8]) -> Alias {
-	simple_hash(&[secret, context])
+fn alias_for(secret: &[u8; 32], context: &[u8]) -> Alias {
+	h(TAG_ALIAS, &[secret, context])
 }
 
-/// Proof for [`Simple`]: a tuple of (member, aliases) where aliases are one per context.
-pub type SimpleProof = ([u8; 32], BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>);
+/// Tag binding the prover (`member`), the contexts, the resulting aliases,
+/// and the message. The verifier reconstructs the same tag and compares.
+fn proof_tag(
+	member: &[u8; 32],
+	contexts: &[&[u8]],
+	aliases: &[Alias],
+	message: &[u8],
+) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	hasher.update(TAG_PROOF);
+	hasher.update(member);
+	hasher.update((contexts.len() as u32).to_le_bytes());
+	for c in contexts {
+		hasher.update((c.len() as u32).to_le_bytes());
+		hasher.update(c);
+	}
+	hasher.update((aliases.len() as u32).to_le_bytes());
+	for a in aliases {
+		hasher.update(a);
+	}
+	hasher.update((message.len() as u32).to_le_bytes());
+	hasher.update(message);
+	hasher.finalize().into()
+}
+
+/// Proof for [`Simple`]: `(member, aliases, tag)` where `tag` is a hash that
+/// binds the member, contexts, aliases, and message together.
+pub type SimpleProof = (
+	[u8; 32],
+	BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>,
+	[u8; 32],
+);
 
 /// Toy [`GenerateVerifiable`] implementation.
-///
-/// - Secret and Member are both `[u8; 32]` (member = secret, i.e. no real key derivation).
-/// - Alias is `hash(secret, context)`.
-/// - Proof is `(member, aliases)` -- verification just checks the member is in the set
-///   and the aliases match.
-/// - Signature is the secret itself (anyone who knows the secret can forge it).
 #[derive(Debug)]
 pub struct Simple;
 
@@ -70,6 +108,9 @@ impl GenerateVerifiable for Simple {
 		_lookup: impl Fn(Range<usize>) -> Result<Vec<Self::StaticChunk>, ()>,
 	) -> Result<(), ()> {
 		for member in members {
+			if inter.contains(&member) {
+				return Err(());
+			}
 			inter.try_push(member).map_err(|_| ())?;
 		}
 		Ok(())
@@ -105,17 +146,18 @@ impl GenerateVerifiable for Simple {
 		(member, _): Self::Commitment,
 		secret: &Self::Secret,
 		contexts: &[&[u8]],
-		_message: &[u8],
+		message: &[u8],
 	) -> Result<(Self::Proof, Vec<Alias>), ()> {
 		if &member != secret {
 			return Err(());
 		}
-		let aliases: Vec<Alias> = contexts
-			.iter()
-			.map(|ctx| simple_alias(secret, ctx))
-			.collect();
-		let bounded_aliases = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
-		Ok(((member, bounded_aliases), aliases))
+		if contexts.len() > MAX_CONTEXTS as usize {
+			return Err(());
+		}
+		let aliases: Vec<Alias> = contexts.iter().map(|ctx| alias_for(secret, ctx)).collect();
+		let bounded = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
+		let tag = proof_tag(&member, contexts, &aliases, message);
+		Ok(((member, bounded, tag), aliases))
 	}
 
 	fn validate_multi_context(
@@ -123,36 +165,47 @@ impl GenerateVerifiable for Simple {
 		proof: &Self::Proof,
 		members: &Self::Members,
 		contexts: &[&[u8]],
-		_message: &[u8],
+		message: &[u8],
 	) -> Result<Vec<Alias>, ()> {
-		let (member, aliases) = proof;
+		let (member, aliases, tag) = proof;
 		if !members.contains(member) {
 			return Err(());
 		}
 		if aliases.len() != contexts.len() {
 			return Err(());
 		}
+		for (alias, ctx) in aliases.iter().zip(contexts.iter()) {
+			if alias != &alias_for(member, ctx) {
+				return Err(());
+			}
+		}
+		let expected_tag = proof_tag(member, contexts, aliases, message);
+		if tag != &expected_tag {
+			return Err(());
+		}
 		Ok(aliases.to_vec())
 	}
 
 	fn alias_in_context(secret: &Self::Secret, context: &[u8]) -> Result<Alias, ()> {
-		Ok(simple_alias(secret, context))
+		Ok(alias_for(secret, context))
 	}
 
 	fn is_member_valid(_member: &Self::Member) -> bool {
 		true
 	}
 
-	fn sign(secret: &Self::Secret, _message: &[u8]) -> Result<Self::Signature, ()> {
-		Ok(*secret)
+	fn sign(secret: &Self::Secret, message: &[u8]) -> Result<Self::Signature, ()> {
+		Ok(h(TAG_SIG, &[secret, message]))
 	}
 
 	fn verify_signature(
 		signature: &Self::Signature,
-		_message: &[u8],
+		message: &[u8],
 		member: &Self::Member,
 	) -> bool {
-		signature == member
+		// Toy: `Member == Secret`, so the verifier recomputes the MAC. This is
+		// trivially forgeable -- the point is that it binds to the message.
+		signature == &h(TAG_SIG, &[member, message])
 	}
 }
 
@@ -160,23 +213,24 @@ impl GenerateVerifiable for Simple {
 mod tests {
 	use super::*;
 
+	fn make_members(secrets: &[[u8; 32]]) -> <Simple as GenerateVerifiable>::Members {
+		let mut inter = Simple::start_members(());
+		let members = secrets.iter().map(Simple::member_from_secret);
+		Simple::push_members(&mut inter, members, |_| Ok(vec![()])).unwrap();
+		Simple::finish_members(inter)
+	}
+
 	#[cfg(feature = "prover")]
 	#[test]
-	fn simple_create_and_verify() {
+	fn create_and_verify() {
 		let alice_sec = Simple::new_secret([0u8; 32]);
 		let bob_sec = Simple::new_secret([1u8; 32]);
 		let charlie_sec = Simple::new_secret([2u8; 32]);
-		let alice = Simple::member_from_secret(&alice_sec);
-		let bob = Simple::member_from_secret(&bob_sec);
-
-		let mut inter = Simple::start_members(());
-		Simple::push_members(&mut inter, [alice, bob].into_iter(), |_| Ok(vec![()])).unwrap();
-		let members = Simple::finish_members(inter);
+		let members = make_members(&[alice_sec, bob_sec]);
 
 		let context = b"ctx";
 		let message = b"hello";
 
-		// Alice can create and verify a proof.
 		type SimpleReceipt = Receipt<Simple>;
 		let receipt = SimpleReceipt::create(
 			(),
@@ -188,7 +242,7 @@ mod tests {
 		.unwrap();
 		let (alias, msg) = receipt.verify((), &members, context).unwrap();
 		assert_eq!(&msg, message);
-		assert_eq!(alias, simple_alias(&alice_sec, context));
+		assert_eq!(alias, alias_for(&alice_sec, context));
 
 		// Charlie (not a member) cannot create a proof.
 		assert!(
@@ -205,13 +259,56 @@ mod tests {
 
 	#[cfg(feature = "prover")]
 	#[test]
-	fn simple_multi_context() {
+	fn proof_binds_to_message() {
+		let secret = Simple::new_secret([7u8; 32]);
+		let member = Simple::member_from_secret(&secret);
+		let members = make_members(&[secret]);
+
+		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
+		let (proof, _) = Simple::create_multi_context(commitment, &secret, &[b"ctx"], b"msg").unwrap();
+
+		assert!(Simple::validate((), &proof, &members, b"ctx", b"msg").is_ok());
+		// Different message must fail.
+		assert!(Simple::validate((), &proof, &members, b"ctx", b"other").is_err());
+	}
+
+	#[cfg(feature = "prover")]
+	#[test]
+	fn proof_binds_to_context() {
+		let secret = Simple::new_secret([7u8; 32]);
+		let member = Simple::member_from_secret(&secret);
+		let members = make_members(&[secret]);
+
+		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
+		let (proof, _) = Simple::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
+
+		assert!(Simple::validate((), &proof, &members, b"a", b"msg").is_ok());
+		// Wrong context must fail (alias mismatch).
+		assert!(Simple::validate((), &proof, &members, b"b", b"msg").is_err());
+	}
+
+	#[cfg(feature = "prover")]
+	#[test]
+	fn proof_rejected_for_non_member() {
+		let prover_sec = Simple::new_secret([7u8; 32]);
+		let prover = Simple::member_from_secret(&prover_sec);
+		let prover_members = make_members(&[prover_sec]);
+
+		let commitment = Simple::open((), &prover, prover_members.iter().cloned()).unwrap();
+		let (proof, _) =
+			Simple::create_multi_context(commitment, &prover_sec, &[b"ctx"], b"msg").unwrap();
+
+		// Different member set that does not contain the prover.
+		let other = make_members(&[Simple::new_secret([8u8; 32])]);
+		assert!(Simple::validate((), &proof, &other, b"ctx", b"msg").is_err());
+	}
+
+	#[cfg(feature = "prover")]
+	#[test]
+	fn multi_context() {
 		let secret = Simple::new_secret([0u8; 32]);
 		let member = Simple::member_from_secret(&secret);
-
-		let mut inter = Simple::start_members(());
-		Simple::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).unwrap();
-		let members = Simple::finish_members(inter);
+		let members = make_members(&[secret]);
 
 		let contexts: Vec<&[u8]> = vec![b"ctx1", b"ctx2"];
 		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
@@ -219,6 +316,7 @@ mod tests {
 			Simple::create_multi_context(commitment, &secret, &contexts, b"msg").unwrap();
 
 		assert_eq!(aliases.len(), 2);
+		assert_ne!(aliases[0], aliases[1]);
 		assert!(Simple::is_valid_multi_context(
 			(),
 			&proof,
@@ -227,13 +325,48 @@ mod tests {
 			&aliases,
 			b"msg"
 		));
+		// Swapped aliases must fail.
+		let swapped = vec![aliases[1], aliases[0]];
+		assert!(!Simple::is_valid_multi_context(
+			(),
+			&proof,
+			&members,
+			&contexts,
+			&swapped,
+			b"msg"
+		));
 	}
 
 	#[test]
-	fn simple_signature() {
+	fn signature_binds_to_message() {
 		let secret = Simple::new_secret([42u8; 32]);
 		let member = Simple::member_from_secret(&secret);
 		let sig = Simple::sign(&secret, b"msg").unwrap();
 		assert!(Simple::verify_signature(&sig, b"msg", &member));
+		// Different message must fail.
+		assert!(!Simple::verify_signature(&sig, b"other", &member));
+		// Different member must fail.
+		let other = Simple::member_from_secret(&Simple::new_secret([43u8; 32]));
+		assert!(!Simple::verify_signature(&sig, b"msg", &other));
+	}
+
+	#[test]
+	fn alias_is_collision_resistant_per_context() {
+		let secret = Simple::new_secret([1u8; 32]);
+		let a1 = Simple::alias_in_context(&secret, b"ctx1").unwrap();
+		let a2 = Simple::alias_in_context(&secret, b"ctx2").unwrap();
+		assert_ne!(a1, a2);
+		// Trailing-zero distinguishability (broken in the old XOR-fold hash).
+		let a3 = Simple::alias_in_context(&secret, b"ctx1\x00").unwrap();
+		assert_ne!(a1, a3);
+	}
+
+	#[test]
+	fn duplicate_member_rejected() {
+		let secret = Simple::new_secret([0u8; 32]);
+		let member = Simple::member_from_secret(&secret);
+		let mut inter = Simple::start_members(());
+		assert!(Simple::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_ok());
+		assert!(Simple::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_err());
 	}
 }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -19,8 +19,8 @@ use super::*;
 use bounded_collections::{BoundedVec, ConstU32};
 use sha2::{Digest, Sha256};
 
-const MAX_MEMBERS: u32 = 1024;
-const MAX_CONTEXTS: u32 = 3;
+pub const MAX_MEMBERS: u32 = 1024;
+pub const MAX_CONTEXTS: u32 = 3;
 
 const TAG_ALIAS: &[u8] = b"verifiable-demo:v1:alias";
 const TAG_SIG: &[u8] = b"verifiable-demo:v1:sig";

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -46,28 +46,28 @@ fn h(domain: &[u8], parts: &[&[u8]]) -> [u8; 32] {
 	hasher.finalize().into()
 }
 
-fn alias_for(secret: &[u8; 32], context: &[u8]) -> Alias {
-	h(TAG_ALIAS, &[secret, context])
+fn make_alias(member: &[u8; 32], context: &[u8]) -> Alias {
+	h(TAG_ALIAS, &[member, context])
 }
 
-/// Tag binding the prover (`member`), the contexts, the resulting aliases,
-/// and the message. The verifier reconstructs the same tag and compares.
-fn proof_tag(member: &[u8; 32], contexts: &[&[u8]], aliases: &[Alias], message: &[u8]) -> [u8; 32] {
-	let mut hasher = Sha256::new();
-	hasher.update(TAG_PROOF);
-	hasher.update(member);
-	hasher.update((contexts.len() as u32).to_le_bytes());
-	for c in contexts {
-		hasher.update((c.len() as u32).to_le_bytes());
-		hasher.update(c);
-	}
-	hasher.update((aliases.len() as u32).to_le_bytes());
-	for a in aliases {
-		hasher.update(a);
-	}
-	hasher.update((message.len() as u32).to_le_bytes());
-	hasher.update(message);
-	hasher.finalize().into()
+fn make_signature(member: &[u8; 32], message: &[u8]) -> [u8; 32] {
+	h(TAG_SIG, &[member, message])
+}
+
+fn make_proof_tag(
+	member: &[u8; 32],
+	contexts: &[&[u8]],
+	aliases: &[Alias],
+	message: &[u8],
+) -> [u8; 32] {
+	let n = (contexts.len() as u32).to_le_bytes();
+	let mut parts: Vec<&[u8]> = Vec::with_capacity(3 + contexts.len() + aliases.len());
+	parts.push(member);
+	parts.push(&n);
+	parts.extend(contexts.iter().copied());
+	parts.extend(aliases.iter().map(|a| a.as_slice()));
+	parts.push(message);
+	h(TAG_PROOF, &parts)
 }
 
 /// Proof for [`Simple`]. The `tag` is a hash that binds the member, contexts,
@@ -150,9 +150,9 @@ impl GenerateVerifiable for Simple {
 		if contexts.len() > MAX_CONTEXTS as usize {
 			return Err(());
 		}
-		let aliases: Vec<Alias> = contexts.iter().map(|ctx| alias_for(secret, ctx)).collect();
+		let aliases: Vec<Alias> = contexts.iter().map(|ctx| make_alias(secret, ctx)).collect();
 		let bounded = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
-		let tag = proof_tag(&member, contexts, &aliases, message);
+		let tag = make_proof_tag(secret, contexts, &aliases, message);
 		let proof = SimpleProof {
 			tag,
 			member,
@@ -180,11 +180,11 @@ impl GenerateVerifiable for Simple {
 			return Err(());
 		}
 		for (alias, ctx) in aliases.iter().zip(contexts.iter()) {
-			if alias != &alias_for(member, ctx) {
+			if alias != &make_alias(member, ctx) {
 				return Err(());
 			}
 		}
-		let expected_tag = proof_tag(member, contexts, aliases, message);
+		let expected_tag = make_proof_tag(member, contexts, aliases, message);
 		if tag != &expected_tag {
 			return Err(());
 		}
@@ -192,7 +192,7 @@ impl GenerateVerifiable for Simple {
 	}
 
 	fn alias_in_context(secret: &Self::Secret, context: &[u8]) -> Result<Alias, ()> {
-		Ok(alias_for(secret, context))
+		Ok(make_alias(secret, context))
 	}
 
 	fn is_member_valid(_member: &Self::Member) -> bool {
@@ -200,7 +200,7 @@ impl GenerateVerifiable for Simple {
 	}
 
 	fn sign(secret: &Self::Secret, message: &[u8]) -> Result<Self::Signature, ()> {
-		Ok(h(TAG_SIG, &[secret, message]))
+		Ok(make_signature(secret, message))
 	}
 
 	fn verify_signature(
@@ -210,7 +210,7 @@ impl GenerateVerifiable for Simple {
 	) -> bool {
 		// Toy: `Member == Secret`, so the verifier recomputes the MAC. This is
 		// trivially forgeable -- the point is that it binds to the message.
-		signature == &h(TAG_SIG, &[member, message])
+		signature == &make_signature(member, message)
 	}
 }
 
@@ -247,19 +247,17 @@ mod tests {
 		.unwrap();
 		let (alias, msg) = receipt.verify((), &members, context).unwrap();
 		assert_eq!(&msg, message);
-		assert_eq!(alias, alias_for(&alice_sec, context));
+		assert_eq!(alias, make_alias(&alice_sec, context));
 
 		// Charlie (not a member) cannot create a proof.
-		assert!(
-			SimpleReceipt::create(
-				(),
-				&charlie_sec,
-				members.iter().cloned(),
-				context,
-				message.to_vec(),
-			)
-			.is_err()
-		);
+		assert!(SimpleReceipt::create(
+			(),
+			&charlie_sec,
+			members.iter().cloned(),
+			context,
+			message.to_vec(),
+		)
+		.is_err());
 	}
 
 	#[cfg(feature = "prover")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ pub trait GenerateVerifiable {
 
 	/// Verify a non-anonymous signature of `message` against the given `member`'s public key.
 	fn verify_signature(signature: &Self::Signature, message: &[u8], member: &Self::Member)
-		-> bool;
+	-> bool;
 }
 
 /// Convenience wrapper bundling a proof with its associated alias and message.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ use core::{fmt::Debug, ops::Range};
 use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use scale_info::*;
 
-#[cfg(feature = "testing")]
-pub mod demo;
+#[cfg(feature = "mock")]
+pub mod mock;
 pub mod ring;
 
 /// Trait for capacity types used in ring operations.
@@ -282,7 +282,7 @@ pub trait GenerateVerifiable {
 
 	/// Verify a non-anonymous signature of `message` against the given `member`'s public key.
 	fn verify_signature(signature: &Self::Signature, message: &[u8], member: &Self::Member)
-	-> bool;
+		-> bool;
 }
 
 /// Convenience wrapper bundling a proof with its associated alias and message.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,4 +1,4 @@
-//! Toy implementation of [`GenerateVerifiable`] for tests.
+//! Mock implementation of [`GenerateVerifiable`] for tests.
 //!
 //! This is a non-cryptographic implementation: there is no anonymity (the proof
 //! reveals which member produced it), and "signatures" are trivially forgeable
@@ -22,11 +22,11 @@ use sha2::{Digest, Sha256};
 pub const MAX_MEMBERS: u32 = 1024;
 pub const MAX_CONTEXTS: u32 = 3;
 
-const TAG_ALIAS: &[u8] = b"verifiable-demo:v1:alias";
-const TAG_SIG: &[u8] = b"verifiable-demo:v1:sig";
-const TAG_PROOF: &[u8] = b"verifiable-demo:v1:proof";
+const TAG_ALIAS: &[u8] = b"verifiable-mock:v1:alias";
+const TAG_SIG: &[u8] = b"verifiable-mock:v1:sig";
+const TAG_PROOF: &[u8] = b"verifiable-mock:v1:proof";
 
-/// [`Capacity`] impl for the demo (no ring VRF).
+/// [`Capacity`] impl for the mock (no ring VRF).
 impl Capacity for () {
 	fn size(&self) -> usize {
 		MAX_MEMBERS as usize
@@ -70,26 +70,26 @@ fn make_proof_tag(
 	h(TAG_PROOF, &parts)
 }
 
-/// Proof for [`Simple`]. The `tag` is a hash that binds the member, contexts,
+/// Proof for [`Mock`]. The `tag` is a hash that binds the member, contexts,
 /// aliases, and message together; the verifier recomputes it and compares.
 #[derive(Default, Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, Debug, TypeInfo)]
-pub struct SimpleProof {
+pub struct MockProof {
 	pub tag: [u8; 32],
 	pub member: [u8; 32],
 	pub aliases: BoundedVec<Alias, ConstU32<MAX_CONTEXTS>>,
 }
 
-/// Toy [`GenerateVerifiable`] implementation.
+/// Mock [`GenerateVerifiable`] implementation.
 #[derive(Debug)]
-pub struct Simple;
+pub struct Mock;
 
-impl GenerateVerifiable for Simple {
+impl GenerateVerifiable for Mock {
 	type Members = BoundedVec<Self::Member, ConstU32<MAX_MEMBERS>>;
 	type Intermediate = BoundedVec<Self::Member, ConstU32<MAX_MEMBERS>>;
 	type Member = [u8; 32];
 	type Secret = [u8; 32];
 	type Commitment = (Self::Member, Vec<Self::Member>);
-	type Proof = SimpleProof;
+	type Proof = MockProof;
 	type Signature = [u8; 32];
 	type StaticChunk = ();
 	type Capacity = ();
@@ -153,7 +153,7 @@ impl GenerateVerifiable for Simple {
 		let aliases: Vec<Alias> = contexts.iter().map(|ctx| make_alias(secret, ctx)).collect();
 		let bounded = BoundedVec::try_from(aliases.clone()).map_err(|_| ())?;
 		let tag = make_proof_tag(secret, contexts, &aliases, message);
-		let proof = SimpleProof {
+		let proof = MockProof {
 			tag,
 			member,
 			aliases: bounded,
@@ -168,7 +168,7 @@ impl GenerateVerifiable for Simple {
 		contexts: &[&[u8]],
 		message: &[u8],
 	) -> Result<Vec<Alias>, ()> {
-		let SimpleProof {
+		let MockProof {
 			tag,
 			member,
 			aliases,
@@ -218,26 +218,26 @@ impl GenerateVerifiable for Simple {
 mod tests {
 	use super::*;
 
-	fn make_members(secrets: &[[u8; 32]]) -> <Simple as GenerateVerifiable>::Members {
-		let mut inter = Simple::start_members(());
-		let members = secrets.iter().map(Simple::member_from_secret);
-		Simple::push_members(&mut inter, members, |_| Ok(vec![()])).unwrap();
-		Simple::finish_members(inter)
+	fn make_members(secrets: &[[u8; 32]]) -> <Mock as GenerateVerifiable>::Members {
+		let mut inter = Mock::start_members(());
+		let members = secrets.iter().map(Mock::member_from_secret);
+		Mock::push_members(&mut inter, members, |_| Ok(vec![()])).unwrap();
+		Mock::finish_members(inter)
 	}
 
 	#[cfg(feature = "prover")]
 	#[test]
 	fn create_and_verify() {
-		let alice_sec = Simple::new_secret([0u8; 32]);
-		let bob_sec = Simple::new_secret([1u8; 32]);
-		let charlie_sec = Simple::new_secret([2u8; 32]);
+		let alice_sec = Mock::new_secret([0u8; 32]);
+		let bob_sec = Mock::new_secret([1u8; 32]);
+		let charlie_sec = Mock::new_secret([2u8; 32]);
 		let members = make_members(&[alice_sec, bob_sec]);
 
 		let context = b"ctx";
 		let message = b"hello";
 
-		type SimpleReceipt = Receipt<Simple>;
-		let receipt = SimpleReceipt::create(
+		type MockReceipt = Receipt<Mock>;
+		let receipt = MockReceipt::create(
 			(),
 			&alice_sec,
 			members.iter().cloned(),
@@ -250,7 +250,7 @@ mod tests {
 		assert_eq!(alias, make_alias(&alice_sec, context));
 
 		// Charlie (not a member) cannot create a proof.
-		assert!(SimpleReceipt::create(
+		assert!(MockReceipt::create(
 			(),
 			&charlie_sec,
 			members.iter().cloned(),
@@ -263,66 +263,66 @@ mod tests {
 	#[cfg(feature = "prover")]
 	#[test]
 	fn proof_binds_to_message() {
-		let secret = Simple::new_secret([7u8; 32]);
-		let member = Simple::member_from_secret(&secret);
+		let secret = Mock::new_secret([7u8; 32]);
+		let member = Mock::member_from_secret(&secret);
 		let members = make_members(&[secret]);
 
-		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
+		let commitment = Mock::open((), &member, members.iter().cloned()).unwrap();
 		let (proof, _) =
-			Simple::create_multi_context(commitment, &secret, &[b"ctx"], b"msg").unwrap();
+			Mock::create_multi_context(commitment, &secret, &[b"ctx"], b"msg").unwrap();
 
-		assert!(Simple::validate((), &proof, &members, b"ctx", b"msg").is_ok());
+		assert!(Mock::validate((), &proof, &members, b"ctx", b"msg").is_ok());
 		// Different message must fail.
-		assert!(Simple::validate((), &proof, &members, b"ctx", b"other").is_err());
+		assert!(Mock::validate((), &proof, &members, b"ctx", b"other").is_err());
 	}
 
 	#[cfg(feature = "prover")]
 	#[test]
 	fn proof_binds_to_context() {
-		let secret = Simple::new_secret([7u8; 32]);
-		let member = Simple::member_from_secret(&secret);
+		let secret = Mock::new_secret([7u8; 32]);
+		let member = Mock::member_from_secret(&secret);
 		let members = make_members(&[secret]);
 
-		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
+		let commitment = Mock::open((), &member, members.iter().cloned()).unwrap();
 		let (proof, _) =
-			Simple::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
+			Mock::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
 
-		assert!(Simple::validate((), &proof, &members, b"a", b"msg").is_ok());
+		assert!(Mock::validate((), &proof, &members, b"a", b"msg").is_ok());
 		// Wrong context must fail (alias mismatch).
-		assert!(Simple::validate((), &proof, &members, b"b", b"msg").is_err());
+		assert!(Mock::validate((), &proof, &members, b"b", b"msg").is_err());
 	}
 
 	#[cfg(feature = "prover")]
 	#[test]
 	fn proof_rejected_for_non_member() {
-		let prover_sec = Simple::new_secret([7u8; 32]);
-		let prover = Simple::member_from_secret(&prover_sec);
+		let prover_sec = Mock::new_secret([7u8; 32]);
+		let prover = Mock::member_from_secret(&prover_sec);
 		let prover_members = make_members(&[prover_sec]);
 
-		let commitment = Simple::open((), &prover, prover_members.iter().cloned()).unwrap();
+		let commitment = Mock::open((), &prover, prover_members.iter().cloned()).unwrap();
 		let (proof, _) =
-			Simple::create_multi_context(commitment, &prover_sec, &[b"ctx"], b"msg").unwrap();
+			Mock::create_multi_context(commitment, &prover_sec, &[b"ctx"], b"msg").unwrap();
 
 		// Different member set that does not contain the prover.
-		let other = make_members(&[Simple::new_secret([8u8; 32])]);
-		assert!(Simple::validate((), &proof, &other, b"ctx", b"msg").is_err());
+		let other = make_members(&[Mock::new_secret([8u8; 32])]);
+		assert!(Mock::validate((), &proof, &other, b"ctx", b"msg").is_err());
 	}
 
 	#[cfg(feature = "prover")]
 	#[test]
 	fn multi_context() {
-		let secret = Simple::new_secret([0u8; 32]);
-		let member = Simple::member_from_secret(&secret);
+		let secret = Mock::new_secret([0u8; 32]);
+		let member = Mock::member_from_secret(&secret);
 		let members = make_members(&[secret]);
 
 		let contexts: Vec<&[u8]> = vec![b"ctx1", b"ctx2"];
-		let commitment = Simple::open((), &member, members.iter().cloned()).unwrap();
+		let commitment = Mock::open((), &member, members.iter().cloned()).unwrap();
 		let (proof, aliases) =
-			Simple::create_multi_context(commitment, &secret, &contexts, b"msg").unwrap();
+			Mock::create_multi_context(commitment, &secret, &contexts, b"msg").unwrap();
 
 		assert_eq!(aliases.len(), 2);
 		assert_ne!(aliases[0], aliases[1]);
-		assert!(Simple::is_valid_multi_context(
+		assert!(Mock::is_valid_multi_context(
 			(),
 			&proof,
 			&members,
@@ -332,7 +332,7 @@ mod tests {
 		));
 		// Swapped aliases must fail.
 		let swapped = vec![aliases[1], aliases[0]];
-		assert!(!Simple::is_valid_multi_context(
+		assert!(!Mock::is_valid_multi_context(
 			(),
 			&proof,
 			&members,
@@ -344,34 +344,34 @@ mod tests {
 
 	#[test]
 	fn signature_binds_to_message() {
-		let secret = Simple::new_secret([42u8; 32]);
-		let member = Simple::member_from_secret(&secret);
-		let sig = Simple::sign(&secret, b"msg").unwrap();
-		assert!(Simple::verify_signature(&sig, b"msg", &member));
+		let secret = Mock::new_secret([42u8; 32]);
+		let member = Mock::member_from_secret(&secret);
+		let sig = Mock::sign(&secret, b"msg").unwrap();
+		assert!(Mock::verify_signature(&sig, b"msg", &member));
 		// Different message must fail.
-		assert!(!Simple::verify_signature(&sig, b"other", &member));
+		assert!(!Mock::verify_signature(&sig, b"other", &member));
 		// Different member must fail.
-		let other = Simple::member_from_secret(&Simple::new_secret([43u8; 32]));
-		assert!(!Simple::verify_signature(&sig, b"msg", &other));
+		let other = Mock::member_from_secret(&Mock::new_secret([43u8; 32]));
+		assert!(!Mock::verify_signature(&sig, b"msg", &other));
 	}
 
 	#[test]
 	fn alias_is_collision_resistant_per_context() {
-		let secret = Simple::new_secret([1u8; 32]);
-		let a1 = Simple::alias_in_context(&secret, b"ctx1").unwrap();
-		let a2 = Simple::alias_in_context(&secret, b"ctx2").unwrap();
+		let secret = Mock::new_secret([1u8; 32]);
+		let a1 = Mock::alias_in_context(&secret, b"ctx1").unwrap();
+		let a2 = Mock::alias_in_context(&secret, b"ctx2").unwrap();
 		assert_ne!(a1, a2);
 		// Trailing-zero distinguishability (broken in the old XOR-fold hash).
-		let a3 = Simple::alias_in_context(&secret, b"ctx1\x00").unwrap();
+		let a3 = Mock::alias_in_context(&secret, b"ctx1\x00").unwrap();
 		assert_ne!(a1, a3);
 	}
 
 	#[test]
 	fn duplicate_member_rejected() {
-		let secret = Simple::new_secret([0u8; 32]);
-		let member = Simple::member_from_secret(&secret);
-		let mut inter = Simple::start_members(());
-		assert!(Simple::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_ok());
-		assert!(Simple::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_err());
+		let secret = Mock::new_secret([0u8; 32]);
+		let member = Mock::member_from_secret(&secret);
+		let mut inter = Mock::start_members(());
+		assert!(Mock::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_ok());
+		assert!(Mock::push_members(&mut inter, [member].into_iter(), |_| Ok(vec![()])).is_err());
 	}
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -250,14 +250,16 @@ mod tests {
 		assert_eq!(alias, make_alias(&alice_sec, context));
 
 		// Charlie (not a member) cannot create a proof.
-		assert!(MockReceipt::create(
-			(),
-			&charlie_sec,
-			members.iter().cloned(),
-			context,
-			message.to_vec(),
-		)
-		.is_err());
+		assert!(
+			MockReceipt::create(
+				(),
+				&charlie_sec,
+				members.iter().cloned(),
+				context,
+				message.to_vec(),
+			)
+			.is_err()
+		);
 	}
 
 	#[cfg(feature = "prover")]
@@ -284,8 +286,7 @@ mod tests {
 		let members = make_members(&[secret]);
 
 		let commitment = Mock::open((), &member, members.iter().cloned()).unwrap();
-		let (proof, _) =
-			Mock::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
+		let (proof, _) = Mock::create_multi_context(commitment, &secret, &[b"a"], b"msg").unwrap();
 
 		assert!(Mock::validate((), &proof, &members, b"a", b"msg").is_ok());
 		// Wrong context must fail (alias mismatch).


### PR DESCRIPTION
Replace the toy demo's XOR-fold hash with domain-separated SHA-256  for alias, signature, and proof tag derivation. Each output now binds all of its inputs (member/secret, contexts, aliases, message) via length-prefixed concatenation under a per-purpose tag, so any swapped input fails verification.

