### PR TITLE
Refactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,69 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.0]
 
-### Added
-- **`DecodeUnchecked` trait for trusted-source SCALE decoding.** Exposes
-  a `decode_unchecked` entry point on the four ring types (`MembersSet`,
-  `MembersCommitment`, `StaticChunk`, `ProverState`) that reads the same
-  wire format as the default SCALE `Decode` impl but skips the arkworks
-  curve-point validation.
-
-## [0.3.0]
+All changes are relative to 0.2.0, the last published version.
 
 ### Breaking Changes
-- **Rename `GenerateVerifiable` trait to `Verifiable`** ([#40](https://github.com/paritytech/verifiable/pull/40))
+
 - **Generic ring VRF implementation** ([#27](https://github.com/paritytech/verifiable/pull/27))
   - `RingVrfVerifiable` is now generic over `RingSuiteExt` instead of being Bandersnatch-specific
-  - Introduced `RingSuiteExt`, `RingCurveParams`, `RingSize`, `FixedBytes` traits
-  - Ring capacity is now configurable via `RingDomainSize` ([#30](https://github.com/paritytech/verifiable/pull/30))
-  - Added `prover` feature gate for proof generation code
-  - `Capacity` trait replaces fixed ring size
+  - Introduced `RingSuiteExt`, `RingCurveParams`, `FixedBytes` traits
+  - Ring capacity is selected via the `Config` associated type, which for the ring
+    implementation is `RingDomainSize` ([#30](https://github.com/paritytech/verifiable/pull/30),
+    [#51](https://github.com/paritytech/verifiable/pull/51), [#52](https://github.com/paritytech/verifiable/pull/52))
+  - Proof generation code gated behind the `prover` feature
 - **Simplify trait API** ([#40](https://github.com/paritytech/verifiable/pull/40))
   - `create` and `validate` are now provided methods delegating to their multi-context counterparts
-  - Plain signatures use IETF VRF proof directly (no VRF output), reducing signature size from 96 to 48 bytes
   - Removed `schnorrkel` dependency
-  - Replaced `Simple` (schnorrkel) and `Trivial` mock implementations with a new dependency-free `Mock` impl in the `mock` module
-  - `mock` module gated behind the `mock` feature
+  - Replaced `Simple` (schnorrkel) and `Trivial` mock implementations with a new dependency-free
+    `Mock` impl in the `mock` module, gated behind the `mock` feature
+- **Plain signatures are Thin VRF proofs** ([#40](https://github.com/paritytech/verifiable/pull/40),
+    [#43](https://github.com/paritytech/verifiable/pull/43))
+  - No VRF output is bundled with the proof, reducing signature size from 96 to 64 bytes
+- **Bounded proof type** ([#41](https://github.com/paritytech/verifiable/pull/41))
+  - `Proof` is now `BoundedVec<u8, MaxRingVrfSignatureLen<S>>` instead of `Vec<u8>`
+  - Added `ring_signature_size` const fn and `RING_PROOF_SIZE`, `VRF_OUTPUT_SIZE`,
+    `MAX_VRF_CONTEXTS` constants to `RingSuiteExt`
+  - Single-context proofs keep the VRF output inline, avoiding a heap allocation
+- **Structured `Error` enum** ([#54](https://github.com/paritytech/verifiable/pull/54))
+  - Fallible trait methods return `Error` instead of `()`
 - **Use uncompressed-unchecked codec for trusted domain types** ([#34](https://github.com/paritytech/verifiable/pull/34))
 
 ### Added
-- **Multi-context proof creation and validation** ([#37](https://github.com/paritytech/verifiable/pull/37), [#40](https://github.com/paritytech/verifiable/pull/40))
+- **Multi-context proof creation and validation** ([#37](https://github.com/paritytech/verifiable/pull/37),
+   [#40](https://github.com/paritytech/verifiable/pull/40))
   - Added `create_multi_context`, `validate_multi_context`, `is_valid_multi_context` methods
+  - `AliasVec`/`ContextVec` are SmallVec-backed ([#53](https://github.com/paritytech/verifiable/pull/53))
 - **Batch proof validation** ([#26](https://github.com/paritytech/verifiable/pull/26))
   - Added `batch_validate` method and `BatchProofItem` type
+- **Pluggable verifier/prover caches.** `RingSuiteExt` carries `VerifierCache` and
+  `ProverCache` associated types (with a `NullCache` no-op impl). The Bandersnatch suite
+  ships static caches so verification does not recompute `PiopParams` on every call
+  ([#44](https://github.com/paritytech/verifiable/pull/44)) and the empty-ring members
+  set is computed once per domain.
+- **`DecodeUnchecked` trait for trusted-source SCALE decoding** ([#56](https://github.com/paritytech/verifiable/pull/56)).
+  Exposes a `decode_unchecked` entry point on the ring types (`MembersSet`,
+  `MembersCommitment`, `StaticChunk`, `ProverState`) that reads the same wire format as
+  the default SCALE `Decode` impl but skips the arkworks curve-point validation. Includes
+  a reusable `MockMembers` newtype in the `mock` module.
+- **`secret-split` feature**: side-channel resistant secret scalar multiplication,
+  bundled into `std` (the only place a production prover runs).
+- **`insecure-deterministic-prover` feature**: deterministic, non-zero-knowledge prover
+  for `no_std` test environments. Enabling `prover` on `no_std` without it is now a
+  compile-time error, since the ring prover has no system RNG there and would panic.
 
-### Changed
-- **Bump `ark-vrf` to 0.3** ([#39](https://github.com/paritytech/verifiable/pull/39))
+### Fixed
+- **Validate curve points on decode to prevent panics** ([#44](https://github.com/paritytech/verifiable/pull/44))
+  - ark-serialize validation is enabled when decoding types that may come from untrusted sources
+- **Reject trailing bytes when deserializing signatures and proofs** ([#48](https://github.com/paritytech/verifiable/pull/48))
+  - Enforces a canonical encoding, preventing malleability via appended bytes
+- **Reject the identity point in member validation and construction** ([#57](https://github.com/paritytech/verifiable/pull/57))
+  - The neutral element passed `is_member_valid` but made `push_members` panic inside the
+    ring backend; both paths now reject it with `Error::InvalidMember`
+  - `push_members` also surfaces `Error::LookupFailed` instead of panicking when the
+    `lookup` callback returns the wrong number of chunks
 
 ## [0.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.7.4", default-features = false, features = [
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false }
-ark-vrf = { git = "https://github.com/davxy/ark-vrf", rev = "3e0f793", default-features = false, features = ["bandersnatch", "ring"] }
+ark-vrf = { version = "0.5.1", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 smallvec = { version = "1", default-features = false }
 sha2 = { version = "0.10", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.7.4", default-features = false, features = [
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 ark-serialize = { version = "0.5", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false }
-ark-vrf = { version = "0.5.0", default-features = false, features = ["bandersnatch", "ring"] }
+ark-vrf = { git = "https://github.com/davxy/ark-vrf", rev = "3e0f793", default-features = false, features = ["bandersnatch", "ring"] }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 smallvec = { version = "1", default-features = false }
 sha2 = { version = "0.10", default-features = false, optional = true }
@@ -70,3 +70,4 @@ insecure-deterministic-prover = [
 # of `GenerateVerifiable`. Intended as a test double for downstream crates
 # that exercise code consuming the trait without the ring-VRF machinery.
 mock = ["sha2"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,4 +70,3 @@ insecure-deterministic-prover = [
 # of `GenerateVerifiable`. Intended as a test double for downstream crates
 # that exercise code consuming the trait without the ring-VRF machinery.
 mock = ["sha2"]
-

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -2,7 +2,7 @@
 use crate::ring::make_ring_context;
 use crate::ring::{
 	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierCache,
-	make_canonical_kzg_vk,
+	make_canonical_pcs_vk,
 };
 pub use ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2;
 
@@ -36,13 +36,11 @@ impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
 		CELLS[domain_size as usize].call_once(|| make_ring_context(domain_size))
 	}
 
-	fn canonical_kzg_vk() -> alloc::borrow::Cow<'static, [u8]> {
+	fn canonical_pcs_vk() -> ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2> {
 		use spin::Once;
-		static CELL: Once<alloc::vec::Vec<u8>> = Once::new();
-		let bytes = CELL.call_once(|| {
-			make_canonical_kzg_vk::<BandersnatchSha512Ell2>(RingDomainSize::VARIANTS[0])
-		});
-		alloc::borrow::Cow::Borrowed(bytes.as_slice())
+		static CELL: Once<ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2>> = Once::new();
+		CELL.call_once(make_canonical_pcs_vk::<BandersnatchSha512Ell2>)
+			.clone()
 	}
 }
 
@@ -194,53 +192,37 @@ mod tests {
 		assert_eq!(signature.len(), S::SIGNATURE_SIZE);
 	}
 
-	/// The canonical KZG verifier key bytes are the same for every domain size:
-	/// the raw key is `(g1, g2, tau*g2)` from the SRS, untouched by domain
-	/// truncation. `VerifierCache::canonical_kzg_vk` caches a single per-suite
-	/// value computed from one domain; this pins the claim that the choice of
-	/// domain doesn't matter, and that the cache serves exactly that value.
+	/// The canonical PCS verifier params are the same for every domain size:
+	/// the raw KZG key is `(g1, g2, tau*g2)` from the SRS, untouched by domain
+	/// truncation. `make_canonical_pcs_vk` relies on this by deriving a single
+	/// per-suite value from an arbitrary domain's embedded data; this pins the
+	/// claim against every domain's data, and that the cache serves that value.
 	#[test]
-	fn canonical_kzg_vk_is_domain_independent() {
-		let values: Vec<_> = RingDomainSize::VARIANTS
-			.iter()
-			.map(|&d| crate::ring::make_canonical_kzg_vk::<BandersnatchSha512Ell2>(d))
-			.collect();
-		assert!(values.iter().all(|v| *v == values[0]));
-		// G1 (96) + 2 x G2 (2 * 192), uncompressed.
-		assert_eq!(values[0].len(), 480);
-		assert_eq!(
-			*BandersnatchVerifierCache::canonical_kzg_vk(),
-			values[0][..]
-		);
+	fn canonical_pcs_vk_is_domain_independent() {
+		let canonical = crate::ring::make_canonical_pcs_vk::<BandersnatchSha512Ell2>();
+		for &domain in RingDomainSize::VARIANTS.iter() {
+			let from_domain = BandersnatchVrfVerifiable::start_members(domain)
+				.0
+				.pcs_verifier_params();
+			assert_eq!(from_domain, canonical);
+		}
+		assert_eq!(BandersnatchVerifierCache::canonical_pcs_vk(), canonical);
 	}
 
-	/// Pin the field-order assumptions behind `make_canonical_kzg_vk` against
-	/// a manual reconstruction from the SRS itself. The raw KZG verifier key is
-	/// built by `w3f-pcs` as `{g1: powers_in_g1[0], g2: powers_in_g2[0],
-	/// tau_in_g2: powers_in_g2[1]}` and serialized in that field order, so the
-	/// bytes extracted from the serialized `RingVerifierKey` must equal those
-	/// three SRS points serialized back to back. If the serialization order of
-	/// `RingVerifierKey` (vk vs. commitment) or of the raw vk's fields ever
-	/// changes, this exact comparison fails.
+	/// The canonical PCS verifier params recovered from the embedded empty-ring
+	/// builder data must be exactly the raw KZG verifier key of the shipped SRS:
+	/// `{g1: powers_in_g1[0], g2: powers_in_g2[0], tau_in_g2: powers_in_g2[1]}`.
+	/// Guards against the embedded builder data drifting from the SRS.
 	#[cfg(feature = "prover")]
 	#[test]
-	fn canonical_kzg_vk_field_order_assumption_holds() {
+	fn canonical_pcs_vk_matches_srs() {
 		let domain = RingDomainSize::Domain11;
 		let pcs_params = &bandersnatch_ring_setup(domain).pcs_params;
 
-		let mut expected = Vec::new();
-		pcs_params.powers_in_g1[0]
-			.serialize_uncompressed(&mut expected)
-			.unwrap();
-		pcs_params.powers_in_g2[0]
-			.serialize_uncompressed(&mut expected)
-			.unwrap();
-		pcs_params.powers_in_g2[1]
-			.serialize_uncompressed(&mut expected)
-			.unwrap();
-
-		let canonical = crate::ring::make_canonical_kzg_vk::<BandersnatchSha512Ell2>(domain);
-		assert_eq!(canonical, expected);
+		let canonical = crate::ring::make_canonical_pcs_vk::<BandersnatchSha512Ell2>();
+		assert_eq!(canonical.g1, pcs_params.powers_in_g1[0]);
+		assert_eq!(canonical.g2, pcs_params.powers_in_g2[0]);
+		assert_eq!(canonical.tau_in_g2, pcs_params.powers_in_g2[1]);
 	}
 
 	/// Verify that proof sizes match the `RingSuiteExt` size constants.

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -1,15 +1,15 @@
 #[cfg(not(feature = "prover"))]
 use crate::ring::make_ring_context;
 use crate::ring::{
-	make_canonical_pcs_vk, make_empty_members_set, Bls12_381Params, RingContext, RingDomainSize,
-	RingSuiteExt, RingVrfVerifiable, VerifierCache,
+	Bls12_381Params, RingContext, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierCache,
+	make_canonical_pcs_vk, make_empty_members_set,
 };
 use alloc::borrow::Cow;
 pub use ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2;
 use spin::Once;
 
 #[cfg(feature = "prover")]
-use crate::ring::{make_ring_setup, ProverCache};
+use crate::ring::{ProverCache, make_ring_setup};
 
 /// Bandersnatch ring VRF Verifiable (BandersnatchSha512Ell2 suite).
 pub type BandersnatchVrfVerifiable = RingVrfVerifiable<BandersnatchSha512Ell2>;
@@ -112,7 +112,7 @@ mod tests {
 	use ark_vrf::ring::SrsLookup;
 
 	use super::*;
-	use crate::{ring::ring_signature_size, GenerateVerifiable};
+	use crate::{GenerateVerifiable, ring::ring_signature_size};
 
 	// Type aliases for Bandersnatch-specific generic types
 	pub type MembersSet = crate::ring::MembersSet<BandersnatchSha512Ell2>;
@@ -305,7 +305,7 @@ mod tests {
 
 #[cfg(test)]
 mod builder_tests {
-	use crate::{ring::ring_verifier_builder_params, GenerateVerifiable};
+	use crate::{GenerateVerifiable, ring::ring_verifier_builder_params};
 
 	use super::*;
 	use ark_scale::MaxEncodedLen;
@@ -314,7 +314,7 @@ mod builder_tests {
 	use parity_scale_codec::{Decode, Encode};
 
 	use tests::{
-		bandersnatch_ring_setup, start_members_from_params, MembersCommitment, MembersSet,
+		MembersCommitment, MembersSet, bandersnatch_ring_setup, start_members_from_params,
 	};
 
 	/// Macro to generate test functions for all implemented domain sizes.
@@ -805,12 +805,10 @@ mod builder_tests {
 		let mut wrong_message_items = batch_items.clone();
 		wrong_message_items[2].message = b"tampered message".to_vec();
 
-		assert!(BandersnatchVrfVerifiable::batch_validate(
-			domain_size,
-			&members,
-			&wrong_message_items,
-		)
-		.is_err());
+		assert!(
+			BandersnatchVrfVerifiable::batch_validate(domain_size, &members, &wrong_message_items,)
+				.is_err()
+		);
 
 		// Test with a proof from a non-member key.
 		// Generate a new key that is NOT in the ring, create a proof using a ring
@@ -1101,14 +1099,16 @@ mod builder_tests {
 		let proof_malleated: <BandersnatchVrfVerifiable as GenerateVerifiable>::Proof =
 			BoundedVec::try_from(bytes).unwrap();
 
-		assert!(BandersnatchVrfVerifiable::validate(
-			domain_size,
-			&proof_malleated,
-			&members,
-			context,
-			message,
-		)
-		.is_err());
+		assert!(
+			BandersnatchVrfVerifiable::validate(
+				domain_size,
+				&proof_malleated,
+				&members,
+				context,
+				message,
+			)
+			.is_err()
+		);
 
 		// Same check via batch_validate.
 		let batch_items = vec![BatchProofItem {
@@ -1185,14 +1185,16 @@ mod builder_tests {
 		let (canonical_proof, _) =
 			BandersnatchVrfVerifiable::create(commitment, &secrets[prover_idx], context, message)
 				.unwrap();
-		assert!(BandersnatchVrfVerifiable::validate(
-			domain_size,
-			&canonical_proof,
-			&canonical_members,
-			context,
-			message,
-		)
-		.is_ok());
+		assert!(
+			BandersnatchVrfVerifiable::validate(
+				domain_size,
+				&canonical_proof,
+				&canonical_members,
+				context,
+				message,
+			)
+			.is_ok()
+		);
 
 		// Attacker setup: a structured reference string from a seed of their
 		// choosing, so the embedded KZG verifier key is not the canonical one.
@@ -1263,8 +1265,8 @@ mod builder_tests {
 	) -> impl Fn(
 		core::ops::Range<usize>,
 	) -> Result<Vec<crate::ring::StaticChunk<BandersnatchSha512Ell2>>, ()>
-	       + Copy
-	       + '_ {
+	+ Copy
+	+ '_ {
 		move |range| {
 			builder_params
 				.lookup(range)

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -30,7 +30,9 @@ impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
 	}
 
 	#[cfg(not(feature = "prover"))]
-	fn get(domain_size: RingDomainSize) -> Cow<'static, RingContext<BandersnatchSha512Ell2>> {
+	fn ring_context(
+		domain_size: RingDomainSize,
+	) -> Cow<'static, RingContext<BandersnatchSha512Ell2>> {
 		type P = RingContext<BandersnatchSha512Ell2>;
 		static CELLS: [Once<P>; RingDomainSize::VARIANTS.len()] =
 			[const { Once::new() }; RingDomainSize::VARIANTS.len()];

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -1,13 +1,15 @@
 #[cfg(not(feature = "prover"))]
 use crate::ring::make_ring_context;
 use crate::ring::{
-	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierCache,
-	make_canonical_pcs_vk, make_empty_members_set,
+	make_canonical_pcs_vk, make_empty_members_set, Bls12_381Params, RingContext, RingDomainSize,
+	RingSuiteExt, RingVrfVerifiable, VerifierCache,
 };
+use alloc::borrow::Cow;
 pub use ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2;
+use spin::Once;
 
 #[cfg(feature = "prover")]
-use crate::ring::{ProverCache, make_ring_setup};
+use crate::ring::{make_ring_setup, ProverCache};
 
 /// Bandersnatch ring VRF Verifiable (BandersnatchSha512Ell2 suite).
 pub type BandersnatchVrfVerifiable = RingVrfVerifiable<BandersnatchSha512Ell2>;
@@ -20,24 +22,22 @@ pub type BandersnatchVrfVerifiable = RingVrfVerifiable<BandersnatchSha512Ell2>;
 pub struct BandersnatchVerifierCache;
 
 impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
-	type Handle = &'static ark_vrf::ring::RingContext<BandersnatchSha512Ell2>;
-
 	#[cfg(feature = "prover")]
-	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		BandersnatchProverCache::get(domain_size).ring_context()
+	fn ring_context(
+		domain_size: RingDomainSize,
+	) -> Cow<'static, RingContext<BandersnatchSha512Ell2>> {
+		Cow::Borrowed(BandersnatchProverCache::setup(domain_size).ring_context())
 	}
 
 	#[cfg(not(feature = "prover"))]
-	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		use spin::Once;
-		type P = ark_vrf::ring::RingContext<BandersnatchSha512Ell2>;
+	fn get(domain_size: RingDomainSize) -> Cow<'static, RingContext<BandersnatchSha512Ell2>> {
+		type P = RingContext<BandersnatchSha512Ell2>;
 		static CELLS: [Once<P>; RingDomainSize::VARIANTS.len()] =
 			[const { Once::new() }; RingDomainSize::VARIANTS.len()];
-		CELLS[domain_size as usize].call_once(|| make_ring_context(domain_size))
+		Cow::Borrowed(CELLS[domain_size as usize].call_once(|| make_ring_context(domain_size)))
 	}
 
-	fn canonical_pcs_vk() -> ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2> {
-		use spin::Once;
+	fn verifier_params() -> ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2> {
 		static CELL: Once<ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2>> = Once::new();
 		CELL.call_once(make_canonical_pcs_vk::<BandersnatchSha512Ell2>)
 			.clone()
@@ -46,7 +46,6 @@ impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
 	fn empty_members_set(
 		domain_size: RingDomainSize,
 	) -> crate::ring::MembersSet<BandersnatchSha512Ell2> {
-		use spin::Once;
 		type M = crate::ring::MembersSet<BandersnatchSha512Ell2>;
 		static CELLS: [Once<M>; RingDomainSize::VARIANTS.len()] =
 			[const { Once::new() }; RingDomainSize::VARIANTS.len()];
@@ -63,15 +62,24 @@ impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
 pub struct BandersnatchProverCache;
 
 #[cfg(feature = "prover")]
-impl ProverCache<BandersnatchSha512Ell2> for BandersnatchProverCache {
-	type Handle = &'static ark_vrf::ring::RingSetup<BandersnatchSha512Ell2>;
-
-	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		use spin::Once;
+impl BandersnatchProverCache {
+	/// Get or construct the cached ring setup for the given domain size.
+	fn setup(
+		domain_size: RingDomainSize,
+	) -> &'static ark_vrf::ring::RingSetup<BandersnatchSha512Ell2> {
 		type P = ark_vrf::ring::RingSetup<BandersnatchSha512Ell2>;
 		static CELLS: [Once<P>; RingDomainSize::VARIANTS.len()] =
 			[const { Once::new() }; RingDomainSize::VARIANTS.len()];
 		CELLS[domain_size as usize].call_once(|| make_ring_setup(domain_size))
+	}
+}
+
+#[cfg(feature = "prover")]
+impl ProverCache<BandersnatchSha512Ell2> for BandersnatchProverCache {
+	fn ring_setup(
+		domain_size: RingDomainSize,
+	) -> Cow<'static, ark_vrf::ring::RingSetup<BandersnatchSha512Ell2>> {
+		Cow::Borrowed(Self::setup(domain_size))
 	}
 }
 
@@ -104,7 +112,7 @@ mod tests {
 	use ark_vrf::ring::SrsLookup;
 
 	use super::*;
-	use crate::{GenerateVerifiable, ring::ring_signature_size};
+	use crate::{ring::ring_signature_size, GenerateVerifiable};
 
 	// Type aliases for Bandersnatch-specific generic types
 	pub type MembersSet = crate::ring::MembersSet<BandersnatchSha512Ell2>;
@@ -116,7 +124,7 @@ mod tests {
 	pub fn bandersnatch_ring_setup(
 		domain_size: RingDomainSize,
 	) -> &'static ark_vrf::ring::RingSetup<BandersnatchSha512Ell2> {
-		<BandersnatchSha512Ell2 as RingSuiteExt>::ProverCache::get(domain_size)
+		BandersnatchProverCache::setup(domain_size)
 	}
 
 	pub fn start_members_from_params(
@@ -230,7 +238,7 @@ mod tests {
 				.pcs_verifier_params();
 			assert_eq!(from_domain, canonical);
 		}
-		assert_eq!(BandersnatchVerifierCache::canonical_pcs_vk(), canonical);
+		assert_eq!(BandersnatchVerifierCache::verifier_params(), canonical);
 	}
 
 	/// The canonical PCS verifier params recovered from the embedded empty-ring
@@ -297,7 +305,7 @@ mod tests {
 
 #[cfg(test)]
 mod builder_tests {
-	use crate::{GenerateVerifiable, ring::ring_verifier_builder_params};
+	use crate::{ring::ring_verifier_builder_params, GenerateVerifiable};
 
 	use super::*;
 	use ark_scale::MaxEncodedLen;
@@ -306,7 +314,7 @@ mod builder_tests {
 	use parity_scale_codec::{Decode, Encode};
 
 	use tests::{
-		MembersCommitment, MembersSet, bandersnatch_ring_setup, start_members_from_params,
+		bandersnatch_ring_setup, start_members_from_params, MembersCommitment, MembersSet,
 	};
 
 	/// Macro to generate test functions for all implemented domain sizes.
@@ -797,10 +805,12 @@ mod builder_tests {
 		let mut wrong_message_items = batch_items.clone();
 		wrong_message_items[2].message = b"tampered message".to_vec();
 
-		assert!(
-			BandersnatchVrfVerifiable::batch_validate(domain_size, &members, &wrong_message_items,)
-				.is_err()
-		);
+		assert!(BandersnatchVrfVerifiable::batch_validate(
+			domain_size,
+			&members,
+			&wrong_message_items,
+		)
+		.is_err());
 
 		// Test with a proof from a non-member key.
 		// Generate a new key that is NOT in the ring, create a proof using a ring
@@ -1091,16 +1101,14 @@ mod builder_tests {
 		let proof_malleated: <BandersnatchVrfVerifiable as GenerateVerifiable>::Proof =
 			BoundedVec::try_from(bytes).unwrap();
 
-		assert!(
-			BandersnatchVrfVerifiable::validate(
-				domain_size,
-				&proof_malleated,
-				&members,
-				context,
-				message,
-			)
-			.is_err()
-		);
+		assert!(BandersnatchVrfVerifiable::validate(
+			domain_size,
+			&proof_malleated,
+			&members,
+			context,
+			message,
+		)
+		.is_err());
 
 		// Same check via batch_validate.
 		let batch_items = vec![BatchProofItem {
@@ -1177,16 +1185,14 @@ mod builder_tests {
 		let (canonical_proof, _) =
 			BandersnatchVrfVerifiable::create(commitment, &secrets[prover_idx], context, message)
 				.unwrap();
-		assert!(
-			BandersnatchVrfVerifiable::validate(
-				domain_size,
-				&canonical_proof,
-				&canonical_members,
-				context,
-				message,
-			)
-			.is_ok()
-		);
+		assert!(BandersnatchVrfVerifiable::validate(
+			domain_size,
+			&canonical_proof,
+			&canonical_members,
+			context,
+			message,
+		)
+		.is_ok());
 
 		// Attacker setup: a structured reference string from a seed of their
 		// choosing, so the embedded KZG verifier key is not the canonical one.
@@ -1257,8 +1263,8 @@ mod builder_tests {
 	) -> impl Fn(
 		core::ops::Range<usize>,
 	) -> Result<Vec<crate::ring::StaticChunk<BandersnatchSha512Ell2>>, ()>
-	+ Copy
-	+ '_ {
+	       + Copy
+	       + '_ {
 		move |range| {
 			builder_params
 				.lookup(range)

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -2,7 +2,7 @@
 use crate::ring::make_ring_context;
 use crate::ring::{
 	Bls12_381Params, RingDomainSize, RingSuiteExt, RingVrfVerifiable, VerifierCache,
-	make_canonical_pcs_vk,
+	make_canonical_pcs_vk, make_empty_members_set,
 };
 pub use ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2;
 
@@ -40,6 +40,18 @@ impl VerifierCache<BandersnatchSha512Ell2> for BandersnatchVerifierCache {
 		use spin::Once;
 		static CELL: Once<ark_vrf::ring::PcsVerifierParams<BandersnatchSha512Ell2>> = Once::new();
 		CELL.call_once(make_canonical_pcs_vk::<BandersnatchSha512Ell2>)
+			.clone()
+	}
+
+	fn empty_members_set(
+		domain_size: RingDomainSize,
+	) -> crate::ring::MembersSet<BandersnatchSha512Ell2> {
+		use spin::Once;
+		type M = crate::ring::MembersSet<BandersnatchSha512Ell2>;
+		static CELLS: [Once<M>; RingDomainSize::VARIANTS.len()] =
+			[const { Once::new() }; RingDomainSize::VARIANTS.len()];
+		CELLS[domain_size as usize]
+			.call_once(|| make_empty_members_set(domain_size))
 			.clone()
 	}
 }
@@ -190,6 +202,18 @@ mod tests {
 		// SIGNATURE_SIZE
 		let signature = BandersnatchVrfVerifiable::sign(&secret, b"test").unwrap();
 		assert_eq!(signature.len(), S::SIGNATURE_SIZE);
+	}
+
+	/// The cached empty-ring members set must be indistinguishable from a fresh
+	/// deserialization of the embedded data, for every domain size.
+	#[test]
+	fn empty_members_set_cache_consistency() {
+		for &domain in RingDomainSize::VARIANTS.iter() {
+			assert_eq!(
+				BandersnatchVerifierCache::empty_members_set(domain),
+				crate::ring::make_empty_members_set(domain),
+			);
+		}
 	}
 
 	/// The canonical PCS verifier params are the same for every domain size:

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -1,12 +1,12 @@
-use alloc::vec;
-use core::{marker::PhantomData, ops::Deref, ops::Range};
+use alloc::{borrow::Cow, vec};
+use core::{marker::PhantomData, ops::Range};
 
 pub use ark_vrf;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_vrf::{
 	reexports::ark_ec::AffineRepr,
-	ring::{RingSuite, Verifier},
+	ring::{RingContext, RingSuite, Verifier},
 	VrfIo,
 };
 use bounded_collections::{BoundedVec, Get};
@@ -153,22 +153,21 @@ pub fn ring_verifier_builder_params<S: RingSuiteExt>(
 }
 
 /// Construct ring context for the given domain size.
-pub fn make_ring_context<S: RingSuiteExt>(
-	domain_size: RingDomainSize,
-) -> ark_vrf::ring::RingContext<S> {
+pub fn make_ring_context<S: RingSuiteExt>(domain_size: RingDomainSize) -> RingContext<S> {
 	let ring_size = domain_size.max_ring_size::<S>();
-	ark_vrf::ring::RingContext::<S>::new(ring_size)
+	RingContext::<S>::new(ring_size)
 }
 
 /// Trait for caching ring context.
-///
-/// The `Handle` associated type allows different caching strategies.
 pub trait VerifierCache<S: RingSuiteExt> {
-	/// Handle type returned by the cache. Must deref to `RingContext<S>`.
-	type Handle: Deref<Target = ark_vrf::ring::RingContext<S>>;
-
 	/// Get or construct ring context for the given domain size.
-	fn get(domain_size: RingDomainSize) -> Self::Handle;
+	///
+	/// The default implementation reconstructs an owned context on every
+	/// call; cache implementations should override this and serve a borrow
+	/// of a value constructed once per domain.
+	fn ring_context(domain_size: RingDomainSize) -> Cow<'static, RingContext<S>> {
+		Cow::Owned(make_ring_context(domain_size))
+	}
 
 	/// The canonical KZG (PCS) verifier params for this suite, as used by the
 	/// verifier-key pinning check in `validate`/`batch_validate`.
@@ -177,7 +176,7 @@ pub trait VerifierCache<S: RingSuiteExt> {
 	/// value per suite. The default implementation recomputes it from the
 	/// embedded empty-ring data on every call; cache implementations should
 	/// override this and serve a value computed once.
-	fn canonical_pcs_vk() -> ark_vrf::ring::PcsVerifierParams<S> {
+	fn verifier_params() -> ark_vrf::ring::PcsVerifierParams<S> {
 		make_canonical_pcs_vk::<S>()
 	}
 
@@ -201,36 +200,25 @@ pub fn make_empty_members_set<S: RingSuiteExt>(domain_size: RingDomainSize) -> M
 }
 
 /// Trait for caching ring setup.
-///
-/// The `Handle` associated type allows different caching strategies.
 #[cfg(feature = "prover")]
 pub trait ProverCache<S: RingSuiteExt> {
-	/// Handle type returned by the cache. Must deref to `RingSetup<S>`.
-	type Handle: Deref<Target = ark_vrf::ring::RingSetup<S>>;
-
 	/// Get or construct ring setup for the given domain size.
-	fn get(domain_size: RingDomainSize) -> Self::Handle;
+	///
+	/// The default implementation reconstructs an owned setup on every call;
+	/// cache implementations should override this and serve a borrow of a
+	/// value constructed once per domain.
+	fn ring_setup(domain_size: RingDomainSize) -> Cow<'static, ark_vrf::ring::RingSetup<S>> {
+		Cow::Owned(make_ring_setup::<S>(domain_size))
+	}
 }
 
-/// Null prover params cache: always constructs new params without caching.
+/// Null params cache: always reconstructs values without caching.
 pub type NullCache = ();
 
 #[cfg(feature = "prover")]
-impl<S: RingSuiteExt> ProverCache<S> for NullCache {
-	type Handle = alloc::boxed::Box<ark_vrf::ring::RingSetup<S>>;
+impl<S: RingSuiteExt> ProverCache<S> for NullCache {}
 
-	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		alloc::boxed::Box::new(make_ring_setup::<S>(domain_size))
-	}
-}
-
-impl<S: RingSuiteExt> VerifierCache<S> for NullCache {
-	type Handle = alloc::boxed::Box<ark_vrf::ring::RingContext<S>>;
-
-	fn get(domain_size: RingDomainSize) -> Self::Handle {
-		alloc::boxed::Box::new(make_ring_context::<S>(domain_size))
-	}
-}
+impl<S: RingSuiteExt> VerifierCache<S> for NullCache {}
 
 /// Fixed-size byte array used to represent a serialized cryptographic object
 /// (public key, proof, or signature).
@@ -628,7 +616,7 @@ fn ensure_canonical_verifier_key<S: RingSuiteExt>(
 ) -> Result<(), Error> {
 	let canonical = MembersCommitment(ark_vrf::ring::verifier_key_from_commitment::<S>(
 		members.0.commitment(),
-		S::VerifierCache::canonical_pcs_vk(),
+		S::VerifierCache::verifier_params(),
 	));
 	if *members != canonical {
 		return Err(Error::VerificationFailed);
@@ -717,7 +705,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<AliasVec, Error> {
 		ensure_canonical_verifier_key::<S>(members)?;
 
-		let verifier_params = S::VerifierCache::get(config);
+		let verifier_params = S::VerifierCache::ring_context(config);
 		let ring_verifier = verifier_params.ring_verifier(members.0.clone());
 
 		let signature = RingVrfSignature::<S>::deserialize_canonical(proof.as_slice())?;
@@ -759,7 +747,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<Vec<Alias>, Error> {
 		ensure_canonical_verifier_key::<S>(members)?;
 
-		let verifier_params = S::VerifierCache::get(config);
+		let verifier_params = S::VerifierCache::ring_context(config);
 		let verifier = verifier_params.ring_verifier(members.0.clone());
 
 		let mut aliases = Vec::with_capacity(proofs.len());
@@ -808,7 +796,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 			.iter()
 			.position(|&m| m == member.0)
 			.ok_or(Error::NotInRing)? as u32;
-		let prover_key = S::ProverCache::get(config)
+		let prover_key = S::ProverCache::ring_setup(config)
 			.prover_key(&pks)
 			.map_err(|_| Error::NotInRing)?;
 		Ok(ProverState {
@@ -831,7 +819,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		}
 		let domain_size =
 			RingDomainSize::try_from(commitment.domain_size).map_err(|_| Error::DecodeError)?;
-		let prover_params = S::ProverCache::get(domain_size);
+		let prover_params = S::ProverCache::ring_setup(domain_size);
 		if commitment.prover_idx >= prover_params.max_ring_size() as u32 {
 			return Err(Error::NotInRing);
 		}

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, vec};
+use alloc::vec;
 use core::{marker::PhantomData, ops::Deref, ops::Range};
 
 pub use ark_vrf;
@@ -170,16 +170,15 @@ pub trait VerifierCache<S: RingSuiteExt> {
 	/// Get or construct ring context for the given domain size.
 	fn get(domain_size: RingDomainSize) -> Self::Handle;
 
-	/// Uncompressed serialization of the canonical KZG verifier key for this
-	/// suite, as used by the verifier-key pinning check in `validate`/
-	/// `batch_validate`.
+	/// The canonical KZG (PCS) verifier params for this suite, as used by the
+	/// verifier-key pinning check in `validate`/`batch_validate`.
 	///
 	/// The value is domain-size independent so there is a single canonical
 	/// value per suite. The default implementation recomputes it from the
 	/// embedded empty-ring data on every call; cache implementations should
 	/// override this and serve a value computed once.
-	fn canonical_kzg_vk() -> Cow<'static, [u8]> {
-		Cow::Owned(make_canonical_kzg_vk::<S>(RingDomainSize::VARIANTS[0]))
+	fn canonical_pcs_vk() -> ark_vrf::ring::PcsVerifierParams<S> {
+		make_canonical_pcs_vk::<S>()
 	}
 }
 
@@ -582,60 +581,38 @@ fn make_alias<S: RingSuiteExt>(output: &ark_vrf::Output<S>) -> Alias {
 	output.hash::<32>()
 }
 
-/// Compute the uncompressed serialization of the canonical KZG verifier key,
-/// recovered from the embedded empty-ring data for `domain`.
+/// Recover the canonical KZG (PCS) verifier params from the suite's embedded
+/// empty-ring data.
 ///
-/// The result is independent of `domain`: the raw KZG key is `(g1, g2, tau*g2)`
+/// The value is domain-size independent: the raw KZG key is `(g1, g2, tau*g2)`
 /// taken from the suite's shipped (Zcash ceremony) SRS, and domain-size
-/// truncation does not touch those points. Any domain works; callers caching a
-/// single per-suite value can pass whichever is cheapest.
-///
-/// This is the one place relying on a serialization-layout fact:
-/// [`ark_vrf::ring::RingVerifierKey`] serializes as `kzg_vk || ring_commitment`,
-/// with the KZG key first, so its length is the total length minus the trailing
-/// commitment's. Both the layout and the domain-independence claim are pinned by
-/// tests in the `bandersnatch` module.
-///
-/// TODO: drop this byte-level recovery once ark-vrf exposes the raw KZG
-/// verifier key; the pinning check then becomes a structural comparison via
-/// `RingVerifierKey::from_commitment_and_kzg_vk` + `Eq`.
-pub fn make_canonical_kzg_vk<S: RingSuiteExt>(domain: RingDomainSize) -> Vec<u8> {
-	// Canonical verifier key for the empty ring at this domain. Its embedded KZG
-	// key is canonical by construction; its commitment is irrelevant here.
-	let canonical =
-		RingVrfVerifiable::<S>::finish_members(RingVrfVerifiable::<S>::start_members(domain));
-
-	let mut bytes = Vec::new();
-	canonical
+/// truncation does not touch those points. The claim is pinned by tests in the
+/// `bandersnatch` module.
+pub fn make_canonical_pcs_vk<S: RingSuiteExt>() -> ark_vrf::ring::PcsVerifierParams<S> {
+	// The embedded empty-ring builder carries the canonical params by
+	// construction; any domain yields the same value, so use the first.
+	RingVrfVerifiable::<S>::start_members(RingDomainSize::VARIANTS[0])
 		.0
-		.serialize_uncompressed(&mut bytes)
-		.expect("serialization into a Vec is infallible");
-	let commitment_len = canonical
-		.0
-		.commitment()
-		.serialized_size(ark_serialize::Compress::No);
-	let vk_len = bytes
-		.len()
-		.checked_sub(commitment_len)
-		.expect("a verifier key embeds its own commitment");
-	bytes.truncate(vk_len);
-	bytes
+		.pcs_verifier_params()
 }
 
 /// Reject a member set whose embedded KZG verifier key is not the canonical one
 /// for this suite.
+///
+/// A verifier key rebuilt from the members' own ring commitment and the
+/// canonical params must equal the members value itself; any difference can
+/// only come from a non-canonical embedded key. The comparison goes through
+/// [`MembersCommitment`]'s encode-based `PartialEq`: the wrapped key type's
+/// derived `Eq` carries unsatisfiable bounds on the PCS scheme marker type, so
+/// it cannot be compared directly.
 fn ensure_canonical_verifier_key<S: RingSuiteExt>(
 	members: &MembersCommitment<S>,
 ) -> Result<(), Error> {
-	let canonical_vk = S::VerifierCache::canonical_kzg_vk();
-	let mut members_bytes = Vec::new();
-	members
-		.0
-		.serialize_uncompressed(&mut members_bytes)
-		.expect("serialization into a Vec is infallible");
-	if members_bytes.len() < canonical_vk.len()
-		|| members_bytes[..canonical_vk.len()] != *canonical_vk
-	{
+	let canonical = MembersCommitment(ark_vrf::ring::verifier_key_from_commitment::<S>(
+		members.0.commitment(),
+		S::VerifierCache::canonical_pcs_vk(),
+	));
+	if *members != canonical {
 		return Err(Error::VerificationFailed);
 	}
 	Ok(())

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -705,8 +705,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<AliasVec, Error> {
 		ensure_canonical_verifier_key::<S>(members)?;
 
-		let verifier_params = S::VerifierCache::ring_context(config);
-		let ring_verifier = verifier_params.ring_verifier(members.0.clone());
+		let verifier_context = S::VerifierCache::ring_context(config);
+		let ring_verifier = verifier_context.ring_verifier(members.0.clone());
 
 		let signature = RingVrfSignature::<S>::deserialize_canonical(proof.as_slice())?;
 
@@ -747,8 +747,8 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	) -> Result<Vec<Alias>, Error> {
 		ensure_canonical_verifier_key::<S>(members)?;
 
-		let verifier_params = S::VerifierCache::ring_context(config);
-		let verifier = verifier_params.ring_verifier(members.0.clone());
+		let verifier_context = S::VerifierCache::ring_context(config);
+		let verifier = verifier_context.ring_verifier(members.0.clone());
 
 		let mut aliases = Vec::with_capacity(proofs.len());
 		let mut batch_verifier = ark_vrf::ring::BatchVerifier::<S>::new(&verifier);
@@ -819,13 +819,13 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		}
 		let domain_size =
 			RingDomainSize::try_from(commitment.domain_size).map_err(|_| Error::DecodeError)?;
-		let prover_params = S::ProverCache::ring_setup(domain_size);
-		if commitment.prover_idx >= prover_params.max_ring_size() as u32 {
+		let ring_setup = S::ProverCache::ring_setup(domain_size);
+		if commitment.prover_idx >= ring_setup.max_ring_size() as u32 {
 			return Err(Error::NotInRing);
 		}
 
 		let ring_prover =
-			prover_params.ring_prover(commitment.prover_key, commitment.prover_idx as usize);
+			ring_setup.ring_prover(commitment.prover_key, commitment.prover_idx as usize);
 
 		let (ios, aliases, outputs): (ContextVec<_>, AliasVec, ContextVec<_>) = contexts
 			.iter()

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -5,9 +5,9 @@ pub use ark_vrf;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_vrf::{
+	VrfIo,
 	reexports::ark_ec::AffineRepr,
 	ring::{RingContext, RingSuite, Verifier},
-	VrfIo,
 };
 use bounded_collections::{BoundedVec, Get};
 use parity_scale_codec::{Decode, Encode};

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -5,9 +5,9 @@ pub use ark_vrf;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_vrf::{
-	VrfIo,
 	reexports::ark_ec::AffineRepr,
 	ring::{RingSuite, Verifier},
+	VrfIo,
 };
 use bounded_collections::{BoundedVec, Get};
 use parity_scale_codec::{Decode, Encode};
@@ -180,6 +180,24 @@ pub trait VerifierCache<S: RingSuiteExt> {
 	fn canonical_pcs_vk() -> ark_vrf::ring::PcsVerifierParams<S> {
 		make_canonical_pcs_vk::<S>()
 	}
+
+	/// The empty-ring [`MembersSet`] for the given domain size, as used by
+	/// `GenerateVerifiable::start_members`.
+	///
+	/// Returned by value since callers mutate it. The default implementation
+	/// deserializes the embedded empty-ring data on every call; cache
+	/// implementations should override this and serve a clone of a value
+	/// deserialized once per domain.
+	fn empty_members_set(domain_size: RingDomainSize) -> MembersSet<S> {
+		make_empty_members_set(domain_size)
+	}
+}
+
+/// Deserialize the empty-ring [`MembersSet`] from the suite's embedded data
+/// for the given domain size.
+pub fn make_empty_members_set<S: RingSuiteExt>(domain_size: RingDomainSize) -> MembersSet<S> {
+	let data = S::CurveParams::empty_ring_commitment(domain_size);
+	MembersSet::deserialize_uncompressed_unchecked(data).expect("embedded empty-ring data is valid")
 }
 
 /// Trait for caching ring setup.
@@ -635,9 +653,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 	type Config = RingDomainSize;
 
 	fn start_members(config: Self::Config) -> Self::Intermediate {
-		// TODO: Optimize by caching the deserialized value; must be compatible with the WASM runtime environment.
-		let data = S::CurveParams::empty_ring_commitment(config);
-		MembersSet::deserialize_uncompressed_unchecked(data).unwrap()
+		S::VerifierCache::empty_members_set(config)
 	}
 
 	fn push_members(


### PR DESCRIPTION
Bumps ark-vrf to 0.5.1 and uses the newly exposed `PcsVerifierParams` and `verifier_key_from_commitment` to replace the byte-level recovery of the canonical KZG verifier key (ref https://github.com/davxy/ark-vrf/pull/95)

The pinning check in `validate/batch_validate` now rebuilds the verifier key from the members' own ring commitment plus the canonical params and compares structurally, dropping the serialization-layout assumption and its TODO.

Reworks the `VerifierCache/ProverCache` traits: the Handle associated type is gone, methods return Cow<'static, _> and come with uncached default implementations, so `NullCache` reduces to empty impls. VerifierCache gains empty_members_set, and the Bandersnatch suite serves the empty-ring members set deserialized once per domain instead of on every start_members call.

