### PR TITLE
Store only the ring commitment in GenerateVerifiable::MembersCommitment

### DIFF
--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -90,7 +90,7 @@ impl RingSuiteExt for ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 {
 
 	const PUBLIC_KEY_SIZE: usize = 32;
 	const MEMBERS_SET_SIZE: usize = 848;
-	const MEMBERS_COMMITMENT_SIZE: usize = 768;
+	const MEMBERS_COMMITMENT_SIZE: usize = 288;
 	const STATIC_CHUNK_SIZE: usize = 96;
 	const SIGNATURE_SIZE: usize = 64;
 	const RING_PROOF_SIZE: usize = 752;
@@ -1267,13 +1267,13 @@ mod builder_tests {
 		assert!(matches!(res, Err(crate::Error::InvalidMember)));
 	}
 
-	// Regression for the trusted-setup pinning fix.
-	// `MembersCommitment` carries its own KZG verifier key, so a member set built
-	// under an attacker-chosen SRS must be rejected by validation logic.
-	// Without the pin the attacker proof below verifies as membership; with it,
-	// the non-canonical root is refused before the pairing check is ever reached.
+	// `MembersCommitment` holds only the ring commitment; verification always
+	// rebuilds the verifier key with the suite's canonical KZG key. A commitment
+	// computed under an attacker-chosen SRS, together with a proof valid under
+	// that SRS, must therefore be rejected: paired with the canonical KZG key it
+	// fails the pairing check.
 	#[test]
-	fn validate_rejects_non_canonical_verifier_key() {
+	fn validate_rejects_foreign_srs_commitment() {
 		use ark_vrf::ring::{Prover, RingSetup};
 
 		type S = BandersnatchSha512Ell2;
@@ -1314,7 +1314,7 @@ mod builder_tests {
 		);
 
 		// Attacker setup: a structured reference string from a seed of their
-		// choosing, so the embedded KZG verifier key is not the canonical one.
+		// choosing, so the ring commitment below is computed under a foreign SRS.
 		let ring_size = domain_size.max_ring_size::<S>();
 		let attacker_setup = RingSetup::<S>::from_seed(ring_size, [0xAB; 32]);
 		let pks: Vec<_> = member_keys
@@ -1322,9 +1322,9 @@ mod builder_tests {
 			.map(|m| crate::ring::decode_member::<S>(m.as_ref()).unwrap().0)
 			.collect();
 
-		// Attacker root: same members, but the verifier key is for the attacker SRS.
+		// Attacker root: same members, but the commitment is for the attacker SRS.
 		let attacker_members =
-			crate::ring::MembersCommitment(attacker_setup.verifier_key(&pks).unwrap());
+			crate::ring::MembersCommitment(attacker_setup.verifier_key(&pks).unwrap().commitment());
 
 		// It differs from the canonical root for the same members.
 		assert_ne!(canonical_members.encode(), attacker_members.encode());
@@ -1353,8 +1353,8 @@ mod builder_tests {
 		let attacker_proof: <BandersnatchVrfVerifiable as GenerateVerifiable>::Proof =
 			bounded_collections::BoundedVec::try_from(buf).unwrap();
 
-		// The non-canonical root is rejected on the verifier-key check, for both the
-		// single and batch verification paths, regardless of the proof supplied.
+		// The foreign-SRS root is rejected at the pairing check, for both the
+		// single and batch verification paths.
 		assert_eq!(
 			BandersnatchVrfVerifiable::validate(
 				domain_size,

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -169,8 +169,9 @@ pub trait VerifierCache<S: RingSuiteExt> {
 		Cow::Owned(make_ring_context(domain_size))
 	}
 
-	/// The canonical KZG (PCS) verifier params for this suite, as used by the
-	/// verifier-key pinning check in `validate`/`batch_validate`.
+	/// The canonical KZG (PCS) verifier params for this suite, used to rebuild
+	/// the ring verifier key from a member set's commitment in
+	/// `validate`/`batch_validate`.
 	///
 	/// The value is domain-size independent so there is a single canonical
 	/// value per suite. The default implementation recomputes it from the
@@ -417,19 +418,22 @@ impl<S: RingSuiteExt> core::fmt::Debug for MembersSet<S> {
 /// This is the compact representation used for proof verification. Produced by
 /// [`GenerateVerifiable::finish_members`] from a [`MembersSet`].
 ///
-/// The wrapped [`ark_vrf::ring::RingVerifierKey`] carries not only the ring
-/// commitment but also its own KZG verifier key, i.e. the trusted setup the
-/// membership check runs under. Only the commitment is the caller's to choose:
-/// verification pins the canonical KZG key shipped with the suite and rejects any
-/// value whose embedded key differs, so a member set decoded from an untrusted
-/// source can misstate membership but never the cryptographic setup.
+/// The wrapped [`ark_vrf::ring::RingCommitment`] is only the commitment to the
+/// ring's fixed columns; it does not carry a KZG verifier key. The trusted setup
+/// the membership check runs under is never read from this value: verification
+/// rebuilds the [`ark_vrf::ring::RingVerifierKey`] from this commitment and the
+/// canonical KZG verifier key shipped with the suite, via
+/// [`ark_vrf::ring::verifier_key_from_commitment`]. A member set decoded from an
+/// untrusted source can therefore misstate membership but cannot influence the
+/// cryptographic setup at all.
 ///
-/// Note the pin covers only the setup embedded in this value. Whether the
-/// commitment honestly represents the claimed member set still depends on it
-/// having been built from canonical SRS chunks; see the trust requirement on
-/// [`GenerateVerifiable::push_members`].
+/// Whether the commitment honestly represents the claimed member set still
+/// depends on it having been built from canonical SRS chunks; see the trust
+/// requirement on [`GenerateVerifiable::push_members`]. A commitment computed
+/// under a different SRS is not a separate concern here: paired with the
+/// canonical KZG key at verification time it simply fails the pairing check.
 #[derive(CanonicalDeserialize, CanonicalSerialize, Clone)]
-pub struct MembersCommitment<S: RingSuiteExt>(pub(crate) ark_vrf::ring::RingVerifierKey<S>);
+pub struct MembersCommitment<S: RingSuiteExt>(pub(crate) ark_vrf::ring::RingCommitment<S>);
 
 impl_common_traits!(MembersCommitment<S: RingSuiteExt>, S::MEMBERS_COMMITMENT_SIZE);
 
@@ -602,26 +606,22 @@ pub fn make_canonical_pcs_vk<S: RingSuiteExt>() -> ark_vrf::ring::PcsVerifierPar
 		.pcs_verifier_params()
 }
 
-/// Reject a member set whose embedded KZG verifier key is not the canonical one
-/// for this suite.
+/// Build the ring [`ark_vrf::ring::RingVerifier`] for a member set.
 ///
-/// A verifier key rebuilt from the members' own ring commitment and the
-/// canonical params must equal the members value itself; any difference can
-/// only come from a non-canonical embedded key. The comparison goes through
-/// [`MembersCommitment`]'s encode-based `PartialEq`: the wrapped key type's
-/// derived `Eq` carries unsatisfiable bounds on the PCS scheme marker type, so
-/// it cannot be compared directly.
-fn ensure_canonical_verifier_key<S: RingSuiteExt>(
+/// The verifier key is rebuilt from the member set's commitment and the
+/// canonical KZG verifier key shipped with the suite, then bound to the ring
+/// context for `config`. The KZG key is always the suite's canonical one, never
+/// anything carried by the (untrusted) member set, so there is nothing to pin: a
+/// commitment built under a foreign SRS just fails the downstream pairing check.
+fn make_ring_verifier<S: RingSuiteExt>(
+	config: RingDomainSize,
 	members: &MembersCommitment<S>,
-) -> Result<(), Error> {
-	let canonical = MembersCommitment(ark_vrf::ring::verifier_key_from_commitment::<S>(
-		members.0.commitment(),
+) -> ark_vrf::ring::RingVerifier<S> {
+	let verifier_key = ark_vrf::ring::verifier_key_from_commitment::<S>(
+		members.0.clone(),
 		S::VerifierCache::verifier_params(),
-	));
-	if *members != canonical {
-		return Err(Error::VerificationFailed);
-	}
-	Ok(())
+	);
+	S::VerifierCache::ring_context(config).ring_verifier(verifier_key)
 }
 
 /// Generic ring VRF implementation parameterized over the ring suite.
@@ -680,7 +680,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 
 	fn finish_members(intermediate: Self::Intermediate) -> Self::Members {
 		let verifier_key = intermediate.0.finalize();
-		MembersCommitment(verifier_key)
+		MembersCommitment(verifier_key.commitment())
 	}
 
 	fn new_secret(entropy: Entropy) -> Self::Secret {
@@ -703,10 +703,7 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		contexts: &[&[u8]],
 		message: &[u8],
 	) -> Result<AliasVec, Error> {
-		ensure_canonical_verifier_key::<S>(members)?;
-
-		let verifier_context = S::VerifierCache::ring_context(config);
-		let ring_verifier = verifier_context.ring_verifier(members.0.clone());
+		let ring_verifier = make_ring_verifier::<S>(config, members);
 
 		let signature = RingVrfSignature::<S>::deserialize_canonical(proof.as_slice())?;
 
@@ -765,12 +762,10 @@ impl<S: RingSuiteExt> GenerateVerifiable for RingVrfVerifiable<S> {
 		} in proofs
 		{
 			if !matches!(&cache, Some(c) if c.config == *config && c.members == members) {
-				ensure_canonical_verifier_key::<S>(members)?;
-				let verifier_context = S::VerifierCache::ring_context(*config);
 				cache = Some(Cache {
 					config: *config,
 					members,
-					verifier: verifier_context.ring_verifier(members.0.clone()),
+					verifier: make_ring_verifier::<S>(*config, members),
 				});
 			}
 			let verifier = &cache


### PR DESCRIPTION
Previously, we stored the entire `RingVerifierKey`, which consists of `MembersCommitment` and `PcsParams`.

Since `PcsParams` are fixed, store only the `MembersCommitment` and reconstruct the `RingVerifierKey` using the cached `PcsParams`.
