### PR TITLE
Replace the insecure deterministic prover with a blinded no-std prover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # `--all-features` is rejected at compile time: `std` (production prover)
-  # and `insecure-deterministic-no-std-prover` (deterministic no_std prover) are
-  # mutually exclusive. Every prover job picks one configuration explicitly.
   PRODUCTION_FEATURES: mock,builder-params
-  DETERMINISTIC_FEATURES: insecure-deterministic-no-std-prover,builder-params,mock
+  NO_STD_PROVER_FEATURES: no-std-prover,builder-params,mock
 
 jobs:
   fmt:
@@ -36,7 +33,7 @@ jobs:
             target
           key: clippy-${{ hashFiles('Cargo.lock') }}
       - run: cargo clippy --features ${{ env.PRODUCTION_FEATURES }} --tests -- -D warnings
-      - run: cargo clippy --no-default-features --features ${{ env.DETERMINISTIC_FEATURES }} --tests -- -D warnings
+      - run: cargo clippy --no-default-features --features ${{ env.NO_STD_PROVER_FEATURES }} --tests -- -D warnings
 
   build:
     name: Build
@@ -51,8 +48,7 @@ jobs:
             target
           key: build-${{ hashFiles('Cargo.lock') }}
       - run: cargo build --features ${{ env.PRODUCTION_FEATURES }}
-      # `std` + `insecure-deterministic-no-std-prover` must be rejected at compile time.
-      - run: "! cargo build --all-features"
+      - run: cargo build --all-features
 
   no-std:
     name: Build no-std (wasm32)
@@ -68,7 +64,7 @@ jobs:
             target
           key: wasm-${{ hashFiles('Cargo.lock') }}
       - run: cargo build --target wasm32-unknown-unknown --no-default-features
-      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features ${{ env.DETERMINISTIC_FEATURES }}
+      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features ${{ env.NO_STD_PROVER_FEATURES }}
 
   test:
     name: Tests
@@ -83,4 +79,4 @@ jobs:
             target
           key: test-${{ hashFiles('Cargo.lock') }}
       - run: cargo test --release --features ${{ env.PRODUCTION_FEATURES }}
-      - run: cargo test --release --no-default-features --features ${{ env.DETERMINISTIC_FEATURES }}
+      - run: cargo test --release --no-default-features --features ${{ env.NO_STD_PROVER_FEATURES }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The no-std-prover run includes tests/no_std_prover.rs, which builds a
+      # no_std wasm fixture and executes the prover under the wasmi interpreter.
+      - run: rustup target add wasm32-unknown-unknown
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
+            tests/fixtures/wasm-prover/target
           key: test-${{ hashFiles('Cargo.lock') }}
       - run: cargo test --release --features ${{ env.PRODUCTION_FEATURES }}
       - run: cargo test --release --no-default-features --features ${{ env.NO_STD_PROVER_FEATURES }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+/tests/fixtures/wasm-prover/target
+/tests/fixtures/wasm-prover/Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,23 +63,22 @@ All changes are relative to 0.2.0, the last published version.
   a reusable `MockMembers` newtype in the `mock` module.
 - **`secret-split` feature**: side-channel resistant secret scalar multiplication,
   bundled into `std` (the only place a production prover runs).
-- **`insecure-deterministic-no-std-prover` feature**: deterministic, non-zero-knowledge prover
-  for `no_std` test environments. Enabling `prover` on `no_std` without it is now a
-  compile-time error, since the ring prover has no system RNG there and would panic.
+- **`no-std-prover` feature**: ring proof generation in `no_std`, with zero-knowledge
+  blinding intact. Blinding randomness is routed through `getrandom`; targets without
+  an OS entropy source (e.g. wasm runtimes) must register a backend with
+  `getrandom::register_custom_getrandom!`, and a missing backend fails at link time.
+  Enabling `prover` on `no_std` without this feature is a compile-time error, since
+  the ring prover would have no randomness source and would panic at proof generation.
 
 ### Security
-- **Feature unification can no longer disable the ring proof's zero-knowledge blinding**
-  (SRLabs audit finding; [ring-proof#93](https://github.com/paritytech/ring-proof/pull/93),
+- **The ring proof's zero-knowledge blinding cannot be disabled**
+  (SRLabs audit finding #710; [ring-proof#93](https://github.com/paritytech/ring-proof/pull/93),
   [ark-vrf#97](https://github.com/davxy/ark-vrf/pull/97))
-  - `insecure-deterministic-no-std-prover` no longer enables `ark-vrf/test-vectors` (removed
-    upstream): the deterministic prover is selected by building this crate's prover
-    ring context via the new runtime `RingContext::new_without_blinding`, so other
-    `ark-vrf` users in the same build are unaffected
-  - Combining `insecure-deterministic-no-std-prover` with `std` (the production proving
-    configuration) is now a compile-time error, mirroring the existing no_std guard
-  - CI builds and tests both supported prover configurations explicitly instead of
-    `--all-features`; a regression test pins blinding on (production) and off
-    (deterministic prover)
+  - A deterministic proof is a function of the witness, so the ring member index
+    becomes recoverable from public data while the proof still verifies
+  - No prover configuration is deterministic: `std` blinds from the system RNG,
+    `no-std-prover` from the embedder's registered `getrandom` backend
+  - A regression test pins blinding on: two proofs over identical inputs must differ
 
 ### Changed
 - **arkworks dependencies bumped to 0.6** (required by the upstream changes above).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/verifiable.git"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
-exclude = ["src/ring/data/bls12-381/zcash-srs-2-16-uncompressed.bin"]
+exclude = [
+    "src/ring/data/bls12-381/zcash-srs-2-16-uncompressed.bin",
+    "tests/fixtures",
+]
 
 [dependencies]
 bounded-collections = { version = "0.3.2", default-features = false, features = ["scale-codec"] }
@@ -30,6 +33,13 @@ sha2 = { version = "0.10", default-features = false, optional = true }
 rand = { version = "0.8", features = ["getrandom"] }
 rand_core = "0.6"
 paste = "1.0"
+wasmi = "0.40"
+
+# Runs the prover in a real no_std wasm module (see tests/no_std_prover.rs).
+# Needs the wasm32-unknown-unknown target installed.
+[[test]]
+name = "no_std_prover"
+required-features = ["no-std-prover", "builder-params"]
 
 [[example]]
 name = "generate_test_keys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ scale-info = { version = "2.11", default-features = false, features = ["derive"]
 ark-serialize = { version = "0.6", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.14", default-features = false }
 ark-vrf = { version = "0.5.2", default-features = false, features = ["bandersnatch", "ring"] }
+# Feature-forward only (see `no-std-prover`): `getrandom_or_panic` is the RNG
+# used for ring proof blinding deep in the proving stack (w3f-plonk-common),
+# `getrandom` is its entropy source. Pin `getrandom_or_panic` to the exact
+# version used by w3f-plonk-common so the feature unifies onto that instance.
+getrandom_or_panic = { version = "0.0.3", default-features = false, optional = true }
+getrandom = { version = "0.2", default-features = false, optional = true }
 spin = { version = "0.9", default-features = false, features = ["once"] }
 smallvec = { version = "1", default-features = false }
 sha2 = { version = "0.10", default-features = false, optional = true }
@@ -56,15 +62,15 @@ prover = []
 # production prover runs. Bundled into `std` for that reason; the deterministic
 # test prover does not need it.
 secret-split = ["ark-vrf/secret-split"]
-# Deterministic, NON-ZERO-KNOWLEDGE prover for `no_std`/test environments.
-# DO NOT USE IN PRODUCTION: the prover's ring context is built without column
-# blinding, so proofs verify normally but are trivially deanonymizable by a
-# passive observer (the ring member index is recoverable from public data).
-# Exists only so the prover can run in `no_std` without a system RNG, for
-# testing. Rejected at compile time when combined with `std`. Only affects
-# provers built by this crate; other `ark-vrf` users in the build are untouched.
-insecure-deterministic-no-std-prover = [
+# Ring proof generation in `no_std`, with zero-knowledge blinding intact.
+# Routes the blinding randomness through `getrandom`. Targets without an OS
+# entropy source (e.g. wasm runtimes) must register a backend with
+# `getrandom::register_custom_getrandom!`; a missing backend fails at link
+# time, never at run time.
+no-std-prover = [
     "prover",
+    "getrandom_or_panic/getrandom",
+    "getrandom/custom",
 ]
 # Exposes the `mock` module with a non-cryptographic `Mock` implementation
 # of `GenerateVerifiable`. Intended as a test double for downstream crates

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ supporting up to 16127 members.
 | `prover` | Proof generation (`open`, `create`, `create_multi_context`) |
 | `secret-split` | Side-channel-resistant secret scalar multiplication (masks the secret before EC multiplication). Requires a system RNG, so it is only enabled under `std` |
 | `builder-params` | Includes precomputed ring builder params for building ring commitments |
-| `insecure-deterministic-no-std-prover` | **Insecure, testing only.** Deterministic `no_std` prover whose proofs are trivially deanonymizable (non-zero-knowledge). Rejected at compile time when combined with `std` |
+| `no-std-prover` | Proof generation in `no_std`, with zero-knowledge blinding intact. Blinding randomness goes through `getrandom`; targets without an OS entropy source (e.g. wasm runtimes) must register a backend with `getrandom::register_custom_getrandom!`. A missing backend fails at link time |
 | `mock` | Exposes the `mock` module with a non-cryptographic `Mock` implementation for tests |
 
 For verifier-only builds (e.g. on-chain), disable default features.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,22 @@
 // Unit tests use `std` unconditionally, so keep it linked for test builds of the
-// no_std configurations (e.g. `insecure-deterministic-no-std-prover` without `std`).
+// no_std configurations (e.g. `no-std-prover` without `std`).
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
-// A production prover needs a system RNG for the ring proof's zero-knowledge
-// blinding (sourced via `getrandom_or_panic` deep in the proving stack). That is
-// only wired up when `std` is enabled; the only no_std prover is the deterministic,
-// non-zero-knowledge one selected by `insecure-deterministic-no-std-prover` (test use
-// only). Any other no_std build with `prover` compiles but panics at proof
+// The ring proof's zero-knowledge blinding draws randomness via
+// `getrandom_or_panic` deep in the proving stack. `std` wires it to the system
+// RNG; `no-std-prover` wires it to `getrandom` (targets without an OS entropy
+// source must register a `getrandom` custom backend, enforced at link time).
+// Without either, a no_std build with `prover` compiles but panics at proof
 // generation, so reject it here instead.
 #[cfg(all(
 	feature = "prover",
 	not(feature = "std"),
-	not(feature = "insecure-deterministic-no-std-prover")
+	not(feature = "no-std-prover")
 ))]
 compile_error!(
-	"`prover` on a no_std target requires the `insecure-deterministic-no-std-prover` feature \
-	 (deterministic, NON-ZERO-KNOWLEDGE, testing only). Without it the ring prover has no \
-	 system RNG and panics during proof generation. Use `std` for production proving."
-);
-
-// Cargo features are additive across the build graph: any crate enabling
-// `insecure-deterministic-no-std-prover` would silently switch every other user of this
-// crate in the same build to the non-zero-knowledge prover. Its proofs verify
-// normally but leak the ring member index, so a `std` build (the production
-// proving configuration) must never carry it.
-#[cfg(all(feature = "std", feature = "insecure-deterministic-no-std-prover"))]
-compile_error!(
-	"`insecure-deterministic-no-std-prover` is a no_std testing prover and must not be combined \
-	 with `std`: it disables the ring proof's zero-knowledge blinding, producing proofs \
-	 that verify normally but are trivially deanonymizable."
+	"`prover` on a no_std target requires the `no-std-prover` feature. Without it the ring \
+	 prover has no randomness source for the zero-knowledge blinding and panics during proof \
+	 generation."
 );
 
 extern crate alloc;

--- a/src/ring/bandersnatch.rs
+++ b/src/ring/bandersnatch.rs
@@ -304,13 +304,11 @@ mod tests {
 		assert_eq!(proof_multi.len(), ring_signature_size::<S>(3));
 	}
 
-	// The ring proof's zero-knowledge blinding must be active in the production
+	// The ring proof's zero-knowledge blinding must be active in every prover
 	// configuration: repeating a proof over identical inputs must give different
 	// bytes (fresh randomness each time). A deterministic proof is a function of
 	// the witness, so the ring member index becomes recoverable from public data
-	// while the proof still verifies (SRLabs finding #710). With
-	// `insecure-deterministic-no-std-prover` blinding is intentionally off and the same
-	// inputs must reproduce the exact same proof. The compile-time feature guards
+	// while the proof still verifies (SRLabs finding #710). A compile-time guard
 	// cannot see an upstream regression (e.g. ring-proof disabling blinding
 	// again); this test does.
 	#[test]
@@ -327,10 +325,7 @@ mod tests {
 				.0
 		};
 		let (first, second) = (prove(), prove());
-		#[cfg(not(feature = "insecure-deterministic-no-std-prover"))]
 		assert_ne!(first, second);
-		#[cfg(feature = "insecure-deterministic-no-std-prover")]
-		assert_eq!(first, second);
 	}
 }
 

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -139,16 +139,7 @@ pub fn make_ring_setup<S: RingSuiteExt>(
 	let pcs_params =
 		ark_vrf::ring::PcsParams::<S>::deserialize_uncompressed_unchecked(data).unwrap();
 	let ring_size = domain_size.max_ring_size::<S>();
-	let setup = ark_vrf::ring::RingSetup::<S>::from_pcs_params(ring_size, pcs_params).unwrap();
-	// Column blinding needs a system RNG, unavailable in no_std. Provers built
-	// from this context produce deterministic, NON-ZERO-KNOWLEDGE proofs, still
-	// valid for verifiers using the regular blinding-enabled context.
-	#[cfg(feature = "insecure-deterministic-no-std-prover")]
-	let setup = ark_vrf::ring::RingSetup {
-		ring_ctx: RingContext::new_without_blinding(ring_size),
-		..setup
-	};
-	setup
+	ark_vrf::ring::RingSetup::<S>::from_pcs_params(ring_size, pcs_params).unwrap()
 }
 
 /// Get ring builder params for the given domain size.

--- a/tests/fixtures/wasm-prover/Cargo.toml
+++ b/tests/fixtures/wasm-prover/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "wasm-prover-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+verifiable = { path = "../../..", default-features = false, features = ["no-std-prover"] }
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }
+dlmalloc = { version = "0.2", features = ["global"] }
+
+[profile.release]
+panic = "abort"
+
+[workspace]

--- a/tests/fixtures/wasm-prover/src/lib.rs
+++ b/tests/fixtures/wasm-prover/src/lib.rs
@@ -1,0 +1,76 @@
+//! Fixture for `tests/no_std_prover.rs`: a genuine `no_std` wasm module that
+//! builds a single-member ring and creates a ring VRF proof inside wasm.
+//! Blinding randomness comes from the registered `getrandom` custom backend
+//! (a deterministic counter stream; each call still draws fresh values).
+//!
+//! The secret entropy, context and message must match the host-side test.
+#![no_std]
+
+extern crate alloc;
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use verifiable::{
+	ring::{bandersnatch::BandersnatchVrfVerifiable, RingDomainSize},
+	GenerateVerifiable,
+};
+
+#[global_allocator]
+static ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+getrandom::register_custom_getrandom!(fill_from_counter);
+
+fn fill_from_counter(dest: &mut [u8]) -> Result<(), getrandom::Error> {
+	static COUNTER: AtomicU64 = AtomicU64::new(0);
+	for chunk in dest.chunks_mut(8) {
+		let word = split_mix_64(COUNTER.fetch_add(1, Ordering::Relaxed));
+		chunk.copy_from_slice(&word.to_le_bytes()[..chunk.len()]);
+	}
+	Ok(())
+}
+
+fn split_mix_64(counter: u64) -> u64 {
+	let mut word = counter.wrapping_add(1).wrapping_mul(0x9E3779B97F4A7C15);
+	word = (word ^ (word >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+	word = (word ^ (word >> 27)).wrapping_mul(0x94D049BB133111EB);
+	word ^ (word >> 31)
+}
+
+static mut OUT: [u8; 2048] = [0; 2048];
+
+#[no_mangle]
+pub extern "C" fn out_ptr() -> *const u8 {
+	core::ptr::addr_of!(OUT).cast()
+}
+
+/// Create a ring proof and store it in `OUT`. Returns the proof length,
+/// or a negative code on failure.
+#[no_mangle]
+pub extern "C" fn prove() -> i32 {
+	let secret = BandersnatchVrfVerifiable::new_secret([0u8; 32]);
+	let member = BandersnatchVrfVerifiable::member_from_secret(&secret);
+	let commitment = match BandersnatchVrfVerifiable::open(
+		RingDomainSize::Domain11,
+		&member,
+		[member].into_iter(),
+	) {
+		Ok(commitment) => commitment,
+		Err(_) => return -1,
+	};
+	let (proof, _alias) = match BandersnatchVrfVerifiable::create(commitment, &secret, b"ctx", b"msg")
+	{
+		Ok(result) => result,
+		Err(_) => return -2,
+	};
+	let out = unsafe { &mut *core::ptr::addr_of_mut!(OUT) };
+	if proof.len() > out.len() {
+		return -3;
+	}
+	out[..proof.len()].copy_from_slice(proof.as_slice());
+	proof.len() as i32
+}
+
+#[panic_handler]
+fn on_panic(_info: &core::panic::PanicInfo) -> ! {
+	core::arch::wasm32::unreachable()
+}

--- a/tests/no_std_prover.rs
+++ b/tests/no_std_prover.rs
@@ -1,0 +1,132 @@
+//! Executes the ring prover in a genuine `no_std` environment.
+//!
+//! The std-linked test suite cannot catch a prover regression that only
+//! surfaces without std (e.g. a new ambient-randomness call deep in the
+//! proving stack): unit tests always link std and the wasm CI job only
+//! compiles an rlib. This test closes that gap. It builds
+//! `tests/fixtures/wasm-prover` (a `no_std` cdylib using `no-std-prover`
+//! with a registered `getrandom` custom backend) for wasm32-unknown-unknown,
+//! runs it under the `wasmi` interpreter and checks that:
+//!
+//! - the module links (a missing randomness source is a link error),
+//! - proof creation completes in wasm (no trap, i.e. no runtime panic),
+//! - two proofs over identical inputs differ (blinding is active in
+//!   `no_std`, the SRLabs finding #710 property),
+//! - both proofs validate on the host and bind to the expected alias.
+//!
+//! Runs in the no-std-prover test configuration (see `[[test]]` in
+//! Cargo.toml) and needs the wasm32-unknown-unknown target installed.
+
+use std::process::Command;
+
+use verifiable::{
+	GenerateVerifiable,
+	ring::{
+		RingDomainSize, StaticChunk,
+		ark_vrf::{ring::SrsLookup, suites::bandersnatch::BandersnatchSha512Ell2},
+		bandersnatch::BandersnatchVrfVerifiable,
+		ring_verifier_builder_params,
+	},
+};
+
+// Must match the fixture (`tests/fixtures/wasm-prover/src/lib.rs`).
+const ENTROPY: [u8; 32] = [0u8; 32];
+const CONTEXT: &[u8] = b"ctx";
+const MESSAGE: &[u8] = b"msg";
+
+const DOMAIN: RingDomainSize = RingDomainSize::Domain11;
+
+fn build_fixture() -> Vec<u8> {
+	let fixture_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/wasm-prover");
+	let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+	let status = Command::new(cargo)
+		.current_dir(fixture_dir)
+		// Host flags and target dir must not leak into the nested wasm build.
+		.env_remove("RUSTFLAGS")
+		.env_remove("CARGO_ENCODED_RUSTFLAGS")
+		.env_remove("CARGO_TARGET_DIR")
+		.args(["build", "--release", "--target", "wasm32-unknown-unknown"])
+		.status()
+		.expect("failed to spawn cargo for the fixture build");
+	assert!(
+		status.success(),
+		"fixture build failed; is the wasm32-unknown-unknown target installed?"
+	);
+	let wasm_path =
+		format!("{fixture_dir}/target/wasm32-unknown-unknown/release/wasm_prover_fixture.wasm");
+	std::fs::read(&wasm_path).unwrap_or_else(|e| panic!("cannot read {wasm_path}: {e}"))
+}
+
+fn run_wasm_prover(wasm: &[u8], calls: usize) -> Vec<Vec<u8>> {
+	let engine = wasmi::Engine::default();
+	let module = wasmi::Module::new(&engine, wasm).expect("fixture is valid wasm");
+	let mut store = wasmi::Store::new(&engine, ());
+	let linker = wasmi::Linker::<()>::new(&engine);
+	let instance = linker
+		.instantiate(&mut store, &module)
+		.expect("fixture needs no imports")
+		.start(&mut store)
+		.expect("fixture start");
+	let prove = instance
+		.get_typed_func::<(), i32>(&store, "prove")
+		.expect("`prove` export");
+	let out_ptr = instance
+		.get_typed_func::<(), i32>(&store, "out_ptr")
+		.expect("`out_ptr` export");
+	let memory = instance
+		.get_memory(&store, "memory")
+		.expect("`memory` export");
+
+	(0..calls)
+		.map(|_| {
+			let len = prove.call(&mut store, ()).expect("prove trapped in wasm");
+			assert!(len > 0, "prove failed in wasm with code {len}");
+			let ptr = out_ptr
+				.call(&mut store, ())
+				.expect("out_ptr trapped in wasm") as usize;
+			let mut proof = vec![0u8; len as usize];
+			memory
+				.read(&store, ptr, &mut proof)
+				.expect("proof read from wasm memory");
+			proof
+		})
+		.collect()
+}
+
+fn members_commitment_for(
+	member: <BandersnatchVrfVerifiable as GenerateVerifiable>::Member,
+) -> <BandersnatchVrfVerifiable as GenerateVerifiable>::Members {
+	let params = ring_verifier_builder_params::<BandersnatchSha512Ell2>(DOMAIN);
+	let mut inter = BandersnatchVrfVerifiable::start_members(DOMAIN);
+	BandersnatchVrfVerifiable::push_members(&mut inter, [member].into_iter(), |range| {
+		(&params)
+			.lookup(range)
+			.map(|points| points.into_iter().map(StaticChunk).collect())
+			.ok_or(())
+	})
+	.expect("push member");
+	BandersnatchVrfVerifiable::finish_members(inter)
+}
+
+#[test]
+fn no_std_wasm_prover_creates_valid_blinded_proofs() {
+	let wasm = build_fixture();
+	let proofs = run_wasm_prover(&wasm, 2);
+
+	// Identical inputs, different bytes: blinding is active in no_std.
+	assert_ne!(proofs[0], proofs[1]);
+
+	let secret = BandersnatchVrfVerifiable::new_secret(ENTROPY);
+	let member = BandersnatchVrfVerifiable::member_from_secret(&secret);
+	let expected_alias = BandersnatchVrfVerifiable::alias_in_context(&secret, CONTEXT).unwrap();
+	let members = members_commitment_for(member);
+
+	for proof_bytes in proofs {
+		let proof: <BandersnatchVrfVerifiable as GenerateVerifiable>::Proof = proof_bytes
+			.try_into()
+			.expect("proof fits the bounded proof type");
+		let alias = BandersnatchVrfVerifiable::validate(DOMAIN, &proof, &members, CONTEXT, MESSAGE)
+			.expect("wasm-created proof validates on the host");
+		assert_eq!(alias, expected_alias);
+	}
+}


### PR DESCRIPTION
The no-std-prover feature keeps zero-knowledge blinding and routes its randomness through `getrandom`. Targets without an OS entropy source must register a custom backend; a missing backend fails at link time. No prover configuration is deterministic anymore, so the std conflict guard is gone and `--all-features` builds again.